### PR TITLE
Update lifetime.md

### DIFF
--- a/docs/api/lifetime.md
+++ b/docs/api/lifetime.md
@@ -27,7 +27,7 @@
 |onUnload|监听页面卸载|||
 |onResize|监听窗口尺寸变化|5+App、微信小程序||
 |onPullDownRefresh|监听用户下拉动作，一般用于下拉刷新，参考[示例](api/ui/pulldown)|||
-|onReachBottom|页面滚动到底部的事件（不是scroll-view滚到底），常用于下拉下一页数据。如使用scroll-view导致页面级没有滚动，则触底事件不会被触发|||
+|onReachBottom|页面滚动到底部的事件（不是scroll-view滚到底），常用于上拉加载下一页数据。如使用scroll-view导致页面级没有滚动，则触底事件不会被触发|||
 |onTabItemTap|点击 tab 时触发，参数为Object，具体见下方注意事项|微信小程序、百度小程序、H5、5+App（自定义组件模式）||
 |onShareAppMessage|用户点击右上角分享|微信小程序、百度小程序、头条小程序、支付宝小程序||
 |onPageScroll|监听页面滚动，参数为Object|||


### PR DESCRIPTION
生命周期 onReachBottom 错误描述为“常用于下拉下一页数据”  实际应为上拉