### PR TITLE
为 h5 chooseImage 实现取消事件的支持

### DIFF
--- a/src/platforms/h5/service/api/media/choose-image.js
+++ b/src/platforms/h5/service/api/media/choose-image.js
@@ -69,9 +69,24 @@ export function chooseImage ({
       tempFilePaths: tempFilePaths,
       tempFiles: tempFiles
     })
-
-    // TODO 用户取消选择时，触发 fail，目前尚未找到合适的方法。
   })
+  
+  // 用户取消选择后，再次产生交互时立刻触发 fail
+  const cancelHandler = function (event) {
+    window.removeEventListener('mousedown', cancelHandler, true)
+    window.removeEventListener('touchstart', cancelHandler, true)
+    if (imageInput) {
+      if (!imageInput.files.length) {
+        invoke(callbackId, {
+          errMsg: 'chooseImage:fail cancel'
+        })
+      }
+      document.body.removeChild(imageInput)
+      imageInput = null
+    }
+  }
+  window.addEventListener('mousedown', cancelHandler, true)
+  window.addEventListener('touchstart', cancelHandler, true)
 
   imageInput.click()
 }


### PR DESCRIPTION
chooseImage 时，先为 window 注册一个 touchstart(capture)，当该事件触发时，检测 files 是否为空，来判断是否是取消事件。