### PR TITLE
docs: 修改官网文档自定义条件编译平台UNI_PLATFORM枚举值

### DIFF
--- a/docs/collocation/package.md
+++ b/docs/collocation/package.md
@@ -28,7 +28,8 @@ package.json扩展配置用法（拷贝代码记得去掉注释！）：
 
 Tips：
 
-- `UNI_PLATFORM`仅支持填写`uni-app`默认支持的基准平台，目前仅限如下枚举值：`app-plus`、`h5`、`mp-weixin`、`mp-alipay`、`mp-baidu`、`mp-toutiao`、`mp-qq`
+- `UNI_PLATFORM`仅支持填写`uni-app`默认支持的基准平台，目前仅限如下枚举值：`h5`、`mp-weixin`、`mp-alipay`、`mp-baidu`、`mp-toutiao`、`mp-qq`
+- 目前不支持App端的自定义条件编译平台
 - `BROWSER` 仅在`UNI_PLATFORM`为`h5`时有效,目前仅限如下枚举值：`Chrome`、`Firefox`、`IE`、`Edge`、`Safari`、`HBuilderX`
 - `package.json`文件中不允许出现注释，否则扩展配置无效
 - `vue-cli`需更新到最新版，HBuilderX需升级到 2.1.6+ 版本


### PR DESCRIPTION
目前还不支持App端的自定义条件编译平台，官方文档中确提供了app-plus基准平台选项。
文档中关于自定义编译平台的UNI_PLATFORM中列出了app-plus选项，是不是会造成误导？建议注明一下，谢谢！
https://ask.dcloud.net.cn/question/82559?item_id=104796&rf=false