### PR TITLE
fix: 将v-uni-image 加入到 transformAssetUrls中

### DIFF
--- a/packages/vue-cli-plugin-uni/lib/h5/index.js
+++ b/packages/vue-cli-plugin-uni/lib/h5/index.js
@@ -118,7 +118,10 @@ module.exports = {
         compiler: getPlatformCompiler(),
         compilerOptions: require('./compiler-options'),
         cacheDirectory: false,
-        cacheIdentifier: false
+        cacheIdentifier: false,
+        transformAssetUrls: {
+          'v-uni-image': 'src'
+        }
       }))
       .end()
       .use('uniapp-custom-block-loader')


### PR DESCRIPTION
问题描述：
在开发h5页面时，如果配置了publicPath，在代码中这样使用image标签：
`... <image class="logo" src="../../static/logo.png"></image> ...`
预期结果:
`... [h("v-uni-image", { staticClass: "logo", attrs: { src: require("cac3") } ...`

实际结果：
`... [h("v-uni-image", { staticClass: "logo", attrs: { src: "../../static/logo.png" } ...`
与预期不符，本PR将v-uni-image的src属性添加到vue-loader的transformAssetUrls的配置中，自动将src转换为require调用，从而解决此问题