### PR TITLE
添加 H5 history 路由情况下的友好链接

### DIFF
--- a/packages/webpack-uni-pages-loader/lib/platforms/h5.js
+++ b/packages/webpack-uni-pages-loader/lib/platforms/h5.js
@@ -66,10 +66,13 @@ const getPageComponents = function (inputDir, pagesJson) {
   removePlatformStyle(process.UNI_H5_PAGES_JSON.globalStyle)
 
   return pages.map(page => {
+    let oriPath = page.path
+    if(pagesJson.simplifyPath) page.path = (typeof(pagesJson.simplifyPath) === 'string' ? pagesJson.simplifyPath: 'pages/') + page.path
+
     const name = page.path.replace(/\//g, '-')
     const pagePath = normalizePath(path.resolve(inputDir, page.path))
     const props = page.style || {}
-    const isEntry = firstPagePath === page.path
+    const isEntry = firstPagePath === oriPath
     const tabBarIndex = tabBarList.findIndex(tabBarPage => tabBarPage.pagePath === page.path)
     const isTabBar = tabBarIndex !== -1
 
@@ -101,12 +104,12 @@ const getPageComponents = function (inputDir, pagesJson) {
     // 删除 app-plus 平台配置
     delete props['app-plus']
     delete props['h5']
-
-    process.UNI_H5_PAGES_JSON.pages[page.path] = props
+      
+    process.UNI_H5_PAGES_JSON.pages[oriPath] = props
 
     return {
       name,
-      route: page.path,
+      route: oriPath,
       path: pagePath,
       props,
       isNVue,


### PR DESCRIPTION
实现路由链接自动没有 'pages/'。

如果在 pages.json 文件上配置了 simplifyPath 为 true了：

![image](https://user-images.githubusercontent.com/745376/69785402-ef229400-11f2-11ea-9173-8fe7a3b2db29.png)

则上图的文件路径为：“pages/index.vue” 和 "pages/my.vue“，路由地址则变为：

    http://localhost:8080/index“

和

     http://localhost:8080/my