### PR TITLE
优化 image 组件

### DIFF
--- a/src/core/view/components/image/index.vue
+++ b/src/core/view/components/image/index.vue
@@ -133,7 +133,7 @@ export default {
       }
     },
     _loadImage () {
-      this.$refs.content.style.backgroundImage = this.src ? `url(${this.realImagePath})` : 'none'
+      this.$refs.content.style.backgroundImage = this.src ? `url("${this.realImagePath}")` : 'none'
 
       const _self = this
       const img = new Image()


### PR DESCRIPTION
使用 image 组件时，如果图片的 url 里带有英文括号，就无法展示图片，原因是设置 backgroundImage 样式的时候没有为 url 里的字符串添加引号，导致 url 与样式的括号冲突

现在稍微修改，加上双引号了 