### PR TITLE
修复video onloadedmetadata判断问题

### DIFF
--- a/src/platforms/h5/service/api/media/choose-video.js
+++ b/src/platforms/h5/service/api/media/choose-video.js
@@ -54,7 +54,7 @@ export function chooseVideo ({
     }
 
     const video = document.createElement('video')
-    if (video.onloadedmetadata) {
+    if (video.onloadedmetadata !== undefined) {
       // 尝试获取视频的宽高信息
       video.onloadedmetadata = function () {
         callbackResult.duration = video.duration || 0


### PR DESCRIPTION
默认video.onloadedmetadata的值是null，是为false;判断video是否支持onloadedmetadata方法应该判断是否是undefined