### PR TITLE
修复 app.json 生成后被部分覆盖的问题

### DIFF
--- a/packages/uni-template-compiler/lib/auto-components.js
+++ b/packages/uni-template-compiler/lib/auto-components.js
@@ -39,7 +39,7 @@ function updateMPUsingAutoImportComponents (autoComponents, options) {
     return
   }
   const resourcePath = options.resourcePath.replace(path.extname(options.resourcePath), '')
-  if (resourcePath == 'App') {
+  if (resourcePath === 'App') {
     return
   }
   const usingAutoImportComponents = Object.create(null)

--- a/packages/uni-template-compiler/lib/auto-components.js
+++ b/packages/uni-template-compiler/lib/auto-components.js
@@ -39,6 +39,9 @@ function updateMPUsingAutoImportComponents (autoComponents, options) {
     return
   }
   const resourcePath = options.resourcePath.replace(path.extname(options.resourcePath), '')
+  if (resourcePath == 'App') {
+    return
+  }
   const usingAutoImportComponents = Object.create(null)
   autoComponents.forEach(({
     name,


### PR DESCRIPTION
fix #1351 
造成 app.json 被覆盖的原因是先生成了正常的 app.json 然后(Windows 下)又被不应该存在的 App.json 覆盖掉了，应去掉 App.json 的生成。