### PR TITLE
feat: h5.router.base 增加相对路径支持

### DIFF
--- a/packages/uni-cli-shared/lib/manifest.js
+++ b/packages/uni-cli-shared/lib/manifest.js
@@ -60,10 +60,10 @@ function getH5Options (manifestJson) {
 
   let base = h5.router.base
 
-  if (base.indexOf('/') !== 0) {
+  if (!base.startsWith('/') && !base.startsWith('./')) {
     base = '/' + base
   }
-  if (base.substr(-1) !== '/') {
+  if (!base.endsWith('/')) {
     base = base + '/'
   }
 
@@ -72,11 +72,17 @@ function getH5Options (manifestJson) {
   if (process.env.NODE_ENV === 'production') { // 生产模式，启用 publicPath
     h5.publicPath = h5.publicPath || base
 
-    if (h5.publicPath.substr(-1) !== '/') {
+    if (!h5.publicPath.endsWith('/')) {
       h5.publicPath = h5.publicPath + '/'
     }
   } else { // 其他模式，启用 base
-    h5.publicPath = base
+
+    if(base.startsWith('./')) {
+       // 在开发模式, publicPath 如果为 './' webpack-dev-server 匹配文件时会失败
+      h5.publicPath = base.substr(1)
+    } else {
+      h5.publicPath = base
+    }
   }
 
   if (process.env.UNI_SUB_PLATFORM === 'mp-360') {


### PR DESCRIPTION
h5.router.base 增加相对路径支持

要在 build 支持相对路径时
只需要配置 manifest `h5.router.base` 为 `'./'`, 配置 `h5.publicPath` 为 `'./'` 或留空不配置
这样 h5 就支持部署在任意路径下

例如，将生成的包放在 www/abcd/ 下，用 nginx 启动 www 目录，则可以通过 /abcd/ 来访问网站。不需要在代码中配置 abcd

优化了 `indexOf`/`substr` 的写法，使用 `startsWith`/`endsWith` 更加语义化

关联 issue #1389 #571 
