### PR TITLE
修正data对象参数stringify

### DIFF
--- a/src/platforms/h5/service/api/network/request.js
+++ b/src/platforms/h5/service/api/network/request.js
@@ -83,6 +83,7 @@ export function request ({
         let bodyArray = []
         for (let key in data) {
           if (data.hasOwnProperty(key)) {
+            if(Object.prototype.toString.call(data[key])==='[object Null]') data[key]=''
             bodyArray.push(encodeURIComponent(key) + '=' + encodeURIComponent(data[key]))
           }
         }


### PR DESCRIPTION
urlencoded下请求参数对象的属性为null时，euc方法编码成‘null’字符串。导致body体参数由‘’变为‘null’。栗子：
{a:1,b:null}=>a=1&b="null"  bad
{a:1,b:null}=>a=1&b=""  better