### PR TITLE
取消固定微信小程序调试基础库版本

### DIFF
--- a/packages/webpack-uni-pages-loader/lib/platforms/mp-weixin/project.config.json
+++ b/packages/webpack-uni-pages-loader/lib/platforms/mp-weixin/project.config.json
@@ -11,7 +11,7 @@
 		"newFeature": true
 	},
 	"compileType": "miniprogram",
-	"libVersion": "2.9.2",
+	"libVersion": "",
 	"appid": "touristappid",
 	"projectname": "",
 	"condition": {


### PR DESCRIPTION
固定为 2.9.2 导致很多新接口在开发者工具都用不了