### PR TITLE
feat(h5): add cancelText prop to ActionSheet

### DIFF
--- a/src/platforms/h5/components/app/popup/actionSheet.vue
+++ b/src/platforms/h5/components/app/popup/actionSheet.vue
@@ -34,7 +34,7 @@
           class="uni-actionsheet__cell"
           @click="_close(-1)"
         >
-          取消
+          {{cancelText}}
         </div>
       </div>
     </div>
@@ -61,6 +61,10 @@ export default {
     visible: {
       type: Boolean,
       default: false
+    },
+    cancelText: {
+      type: String,
+      default: '取消'
     }
   },
   methods: {


### PR DESCRIPTION
Enables users to customise the close text of ActionSheet and by default the text is "取消". 
This update also makes sure that this component can be used in English.