### PR TITLE
支付宝app上添加onShareAppMessage事件

### DIFF
--- a/src/platforms/mp-weixin/runtime/wrapper/app-base-parser.js
+++ b/src/platforms/mp-weixin/runtime/wrapper/app-base-parser.js
@@ -85,7 +85,10 @@ export default function parseBaseApp (vm, {
       appOptions[name] = methods[name]
     })
   }
-
+  let shareHookName = 'onShareAppMessage'
+  if(vm.$options[shareHookName] && (hooks.indexOf(shareHookName) === -1)){
+    hooks.push(shareHookName)
+  }
   initHooks(appOptions, hooks)
 
   return appOptions


### PR DESCRIPTION
 支持支付宝小程序，在app上添加onShareAppMessage事件，跟onLaunch同级 ，通常用户会以为跟Page的写法一致，而不是写在methods中