### PR TITLE
解决在和swiper组合使用(官方demo)中先横向滑动后还能同时触发下拉的问题

### DIFF
--- a/src/core/view/components/scroll-view/index.vue
+++ b/src/core/view/components/scroll-view/index.vue
@@ -202,6 +202,8 @@ export default {
     }
     var touchStart = null
     var needStop = null
+    //滑动是在横向开启的？
+    var startOnX=null
     this.__handleTouchMove = function (event) {
       var x = event.touches[0].pageX
       var y = event.touches[0].pageY
@@ -209,6 +211,8 @@ export default {
       if (needStop === null) {
         if (Math.abs(x - touchStart.x) > Math.abs(y - touchStart.y)) {
           // 横向滑动
+          //滑动是在横向开启的
+          startOnX=true
           if (self.scrollX) {
             if (main.scrollLeft === 0 && x > touchStart.x) {
               needStop = false
@@ -240,8 +244,8 @@ export default {
       if (needStop) {
         event.stopPropagation()
       }
-
-      if (self.refresherEnabled && self.refreshState === 'pulling') {
+      //滑动是在横向开启的时候不再触发下拉
+      if (!startOnX&&self.refresherEnabled && self.refreshState === 'pulling') {
         const dy = y - touchStart.y
         self.refresherHeight = dy
 
@@ -265,6 +269,8 @@ export default {
           disable: true
         })
         needStop = null
+        //初始化滑动是f否
+        startOnX=null
         touchStart = {
           x: event.touches[0].pageX,
           y: event.touches[0].pageY


### PR DESCRIPTION
原组件在和swiper组合使用时（官方demo顶部导航选项卡在使用非原生模式的时候，并且将scroll-view的refresherEnabled为true时）滑动切换会在横向滑动切换swiper项时会同时触发下拉刷新，导致斜拉效果，影响体验，现在增加变量x，在横向开启的滑动中赋值x为true，如果x为true不再触发下拉事件