### PR TITLE
fix: 修复cnpm安装依赖时loader路径match错误的问题

### DIFF
--- a/packages/vue-cli-plugin-uni/lib/configure-webpack.js
+++ b/packages/vue-cli-plugin-uni/lib/configure-webpack.js
@@ -140,8 +140,8 @@ module.exports = function configureWebpack (platformOptions, manifestPlatformOpt
       }
     }
   }
-  const babelLoaderRe = /^babel-loader|(\/|\\)babel-loader/
-  const cacheLoaderRe = /^cache-loader|(\/|\\)cache-loader/
+  const babelLoaderRe = /^babel-loader|(\/|\\)_?babel-loader/
+  const cacheLoaderRe = /^cache-loader|(\/|\\)_?cache-loader/
   return function (webpackConfig) {
     // disable js cache-loader
     const rawRules = webpackConfig.module.rules


### PR DESCRIPTION
模块：
vue-cli-plugin-uni

版本：
"@vue/cli-service": "4.5.0"
"@vue/cli-plugin-babel": "4.5.0“
"@dcloudio/vue-cli-plugin-uni": "^2.0.0-28820200820001"

问题：
由于cnpm install的机制，node_modules中package路径名字前会带上”_“下划线，例如: 
\\node_modules\\_babel-loader@8.1.0@babel-loader\\lib\\index.js
原代码中的babel的loader正则 /^babel-loader|(\/|\\)babel-loader/ 对路径的test结果为false，导致匹配不到对应loader。

此问题会导致基于vue-cli编译的项目在用cnpm安装依赖的项目，在编译时，报错：No matching use for foo.js。类似的issue: [1683](https://github.com/dcloudio/uni-app/issues/1683)

解决:
修改loader正则兼容cnpm安装路径
/^babel-loader|(\/|\\)_?babel-loader/

补充:
可能其他基于路径匹配的loader，在cnpm安装依赖时也会有相应问题。
