### PR TITLE
删除uni.navigateTo 目标页面获取数据之前发送数据的代码

### DIFF
--- a/docs/api/router.md
+++ b/docs/api/router.md
@@ -67,8 +67,6 @@ uni.navigateTo({
 onLoad: function(option) {
   console.log(option.query)
   const eventChannel = this.getOpenerEventChannel()
-  eventChannel.emit('acceptDataFromOpenedPage', {data: 'test'});
-  eventChannel.emit('someEvent', {data: 'test'});
   // 监听acceptDataFromOpenerPage事件，获取上一页面通过eventChannel传送到当前页面的数据
   eventChannel.on('acceptDataFromOpenerPage', function(data) {
     console.log(data)


### PR DESCRIPTION
目标页面获取数据时只需要订阅相关eventChannel的事件即可，示例中订阅之前先发送数据似乎是多余的，容易造成误解