### PR TITLE
Update payment.md

### DIFF
--- a/docs/api/plugins/payment.md
+++ b/docs/api/plugins/payment.md
@@ -141,7 +141,7 @@ App 支付
 ```javascript
 uni.requestPayment({
     provider: 'alipay',
-    orderInfo: 'orderInfo', //微信、支付宝订单数据
+    orderInfo: 'orderInfo', //微信、支付宝订单数据 【注意微信的订单信息，键值应该全部是小写，不能采用驼峰命名】
     success: function (res) {
         console.log('success:' + JSON.stringify(res));
     },


### PR DESCRIPTION
iOS端接入UNI SDK小程序 -----------这面后台测试时候发现，如果微信支付order对象，里的键值为驼峰时候，调用`uni.requestPayment`方法，`success `和`fail `回调均不会走，很诡异！所以需要特别在这里提示下，这个问题坑了我好久，最终我调试uni源代码才发现该问题所在，浪费了好多时间。