### PR TITLE
Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -67,7 +67,7 @@
       </a>
     </div>
     <p>注：<br/>
-        <em>- 某些平台不能提交简单demo，故补充了一些其他功能；hello uni-app示例代码可从[github](https://github.com/dcloudio/hello-uniapp)获取</em></br>
+        <em>- 某些平台不能提交简单demo，故补充了一些其他功能；hello uni-app示例代码可从[github](https://github.com/dcloudio/hello-uniapp)</em><em>获取</em></br>
         <em>- 快应用仅支持 vivo 、oppo、华为</em></br>
         <em>- 360小程序仅 windows平台支持，需要在360浏览器中打开</em></br>
     </p>


### PR DESCRIPTION
**问题描述**
70行的超链接将 ")获取" 也包含进去了，导致链接未访问到指定内容
修改：加了一个强调内容标签把 “获取” 隔开了。

**复现步骤**
![image](https://user-images.githubusercontent.com/43030408/93964046-3769fe80-fd91-11ea-80ec-9284aa313612.png)


**预期结果**
![image](https://user-images.githubusercontent.com/43030408/93964097-5f596200-fd91-11ea-9d00-ac22ed72b1fb.png)


**实际结果**
![image](https://user-images.githubusercontent.com/43030408/93964145-83b53e80-fd91-11ea-8baf-e36bb0e70937.png)


**系统信息**
浏览器：Google Chrome
