### PR TITLE
fix: 解决其他环境build后的index.html文件路径问题，除了开发模式，其他模式都启用 publicPath

### DIFF
--- a/packages/uni-cli-shared/lib/manifest.js
+++ b/packages/uni-cli-shared/lib/manifest.js
@@ -69,7 +69,7 @@ function getH5Options (manifestJson) {
 
   h5.router.base = base
 
-  if (process.env.NODE_ENV === 'production') { // 生产模式，启用 publicPath
+  if (process.env.NODE_ENV !== 'development') { // 除了开发模式，其他模式都启用 publicPath
     h5.publicPath = h5.publicPath || base
 
     if (!h5.publicPath.endsWith('/')) {


### PR DESCRIPTION
我司项目会存在多个环境，例如：开发环境、测试环境、预发布环境、生产环境......

我在`build`命令时注入了指定的NODE_ENV变量

![image](https://user-images.githubusercontent.com/19791710/95728798-84fdcb00-0cae-11eb-9e7b-89a438fe124b.png)

[packages/uni-cli-shared/lib/manifest.js](https://github.com/dcloudio/uni-app/blob/master/packages/uni-cli-shared/lib/manifest.js#L72)中，只对生产模式启用了`publicPath`，那当进行测试环境或者预发布环境的`build`时，`build`后的`index.html`中的css路径、以及js路径就不正确了。

我稍微修改了一下，除了开发模式(`development`)，其他模式都启用`publicPath`，这样可以解决其他环境`build`后的`index.html`文件路径问题，