### PR TITLE
fix: 修复 image 组件 contentPath 字段默认为空导致 img 请求空问题

### DIFF
--- a/src/core/view/components/image/index.vue
+++ b/src/core/view/components/image/index.vue
@@ -4,7 +4,10 @@
       ref="content"
       :style="style"
     />
-    <img :src="contentPath">
+    <img
+      v-if="contentPath"
+      :src="contentPath"
+    >
     <v-uni-resize-sensor
       v-if="mode === 'widthFix' || mode === 'heightFix'"
       ref="sensor"


### PR DESCRIPTION
https://github.com/dcloudio/uni-app/blob/9fa8d6953058226b7ccf7745f4c6c2a58fedc2c7/src/core/view/components/image/index.vue#L7
新增判断contentPath有值再渲染img
```html
    <img
      v-if="contentPath"
      :src="contentPath"
    >
```