### PR TITLE
Update request.js:

### DIFF
--- a/src/platforms/quickapp-native/service/api/network/request.js
+++ b/src/platforms/quickapp-native/service/api/network/request.js
@@ -40,7 +40,7 @@ export function createRequestTaskById (requestTaskId, {
     url: url.trim(),
     header,
     type: responseType,
-    timeout: timeout || 6e5
+    timeout: timeout
   }
   if (method !== 'GET') {
     options.data = data


### PR DESCRIPTION
Hello,

In the file request.js, variable `options` is declared in the following way:

`
const options = {
    method,
    url: url.trim(),
    header,
    type: responseType,
    timeout: timeout || 6e5
  }
`

My pull request changes this to:

`
const options = {
    method,
    url: url.trim(),
    header,
    type: responseType,
    timeout: timeout
  }
`

as variable `timeout` is at the time of declaration of `options` set to `60000`, meaning the first operand of the OR-operation will always be used to assign `options.timeout` and can thus replace the whole OR-operation.


Kind regards,
Florian