### PR TITLE
fix split indirect refer js module into subpackage when split chunks

### DIFF
--- a/packages/vue-cli-plugin-uni/lib/split-chunks.js
+++ b/packages/vue-cli-plugin-uni/lib/split-chunks.js
@@ -180,6 +180,8 @@ module.exports = function getSplitChunks () {
               }
               return true
             }
+          } else {
+            return hasMainPackageComponent(m.module, subPackageRoot)
           }
         }
       }


### PR DESCRIPTION
在分包代码优化过程中，进一步解决第三组件间接引用的js module被拆分到子包中。
Fixes #2196