### PR TITLE
fix: 支付宝小程序 pageScrollTo 已支持 duration

### DIFF
--- a/src/platforms/mp-alipay/runtime/api/protocols.js
+++ b/src/platforms/mp-alipay/runtime/api/protocols.js
@@ -365,11 +365,6 @@ const protocols = { // 需要做转换的 API 列表
       text: 'data'
     }
   },
-  pageScrollTo: {
-    args: {
-      duration: false
-    }
-  },
   login: {
     name: 'getAuthCode',
     returnValue (result) {


### PR DESCRIPTION
支付宝中的 [pageScrollTo](https://opendocs.alipay.com/mini/api/scroll) 从 `1.20.0` 起已经支持 `duration` 参数