### PR TITLE
Update router.md

### DIFF
--- a/docs/api/router.md
+++ b/docs/api/router.md
@@ -77,7 +77,7 @@ onLoad: function(option) {
 ```
 
 
-url有长度限制，太长的字符串会传递失败，可使用[窗体通信](https://uniapp.dcloud.io/collocation/frame/communication)、[全局变量](https://ask.dcloud.net.cn/article/35021)，或`encodeURIComponent`等多种方式解决，如下为`encodeURIComponent`示例。
+url当作参数传递的时候，如参数出现空格这样的特殊字段，只可以读取到空格前的内容，后面内容丢失导致传递失败，可使用[窗体通信](https://uniapp.dcloud.io/collocation/frame/communication)、[全局变量](https://ask.dcloud.net.cn/article/35021)，或`encodeURIComponent`等多种方式解决，如下为`encodeURIComponent`示例。
 ```html
 <navigator :url="'/pages/test/test?item='+ encodeURIComponent(JSON.stringify(item))"></navigator>
 ```


### PR DESCRIPTION
encodeURIComponent并不会使url变短，所以造成参数传递失败的原因并不是url太长造成的。而是因为url当作参数传递的时候，如参数出现空格这样的特殊字段，只可以读取到空格前的内容，后面内容丢失，但是如果用encodeURIComponent()包裹一下，那会将这些特殊字符进行转义，这样可以完整读取了，所以encodeURIComponent()用于url作为参数传递的场景中使用。参考：https://blog.csdn.net/weixin_42520375/article/details/103863487