### PR TITLE
feat: 增加ignoreBaseWidth属性, h5中大屏rpx转换时可以适配, 而不是固定基准值

### DIFF
--- a/docs/adapt.md
+++ b/docs/adapt.md
@@ -37,7 +37,7 @@ pages.json 配置样例
 ```json
 {
   "globalStyle": {
-    
+
   },
   "topWindow": {
     "path": "responsive/top-window.vue", // 指定 topWindow 页面文件
@@ -197,7 +197,8 @@ uni-app的屏幕适配推荐方案是运行时动态适配，而不是为PC版�
   "globalStyle": {
     "rpxCalcMaxDeviceWidth": 960, // rpx 计算所支持的最大设备宽度，单位 px，默认值为 960
     "rpxCalcBaseDeviceWidth": 375, // rpx 计算使用的基准设备宽度，设备实际宽度超出 rpx 计算所支持的最大设备宽度时将按基准宽度计算，单位 px，默认值为 375
-    "rpxCalcIncludeWidth": 750 // rpx 计算特殊处理的值，始终按实际的设备宽度计算，单位 rpx，默认值为 750
+    "rpxCalcIncludeWidth": 750, // rpx 计算特殊处理的值，始终按实际的设备宽度计算，单位 rpx，默认值为 750
+    "ignoreBaseWidth": false // 是否需要忽略超过最大值时按rpxCalcBaseDeviceWidth基准值进行计算, 默认false, 为true时, 在超过最大值且横屏时会按2048的设计稿进行换算, 即 750rpx ---> 750 * windowWidth / 2048(假设屏幕宽度为1024, 则换算后为 375px)
   },
 }
 ```
@@ -207,6 +208,8 @@ uni-app的屏幕适配推荐方案是运行时动态适配，而不是为PC版�
 但是，rpx的最大适配宽度被限定后，会带来一个新问题：如果您的代码中把750rpx当做100%来使用（官方强烈不推荐这种写法，即便是nvue不支持百分比，也应该使用flex来解决撑满问题），此时不管屏幕宽度为多少，哪怕超过了960px，您的预期仍然是要占满整个屏幕宽度，但如果按rpxCalcBaseDeviceWidth的375px的策略执行将不再占满屏宽。
 
 此时您有两种解决方案，一种是修改代码，将里面把rpx当做百分比的代码改掉；另一种是配置rpxCalcIncludeWidth，设置某个特定数值不受rpxCalcMaxDeviceWidth约束。如上述例子中的"rpxCalcIncludeWidth": 750，代表着如果写了 750rpx，始终将按屏幕宽度百分百占满来计算。
+
+若不启用ignoreBaseWidth, 则在超过最大宽度后, 不管多宽的屏幕都是只按设定的 rpxCalcBaseDeviceWidth 基准值计算, 无法适配缩放; 启用ignoreBaseWidth后, 则可在小屏幕时按750设计稿尺寸适配换算, 大屏幕且横屏时按2048设计稿尺寸适配换算
 
 - 关于 rpx 转 px
 

--- a/docs/collocation/pages.md
+++ b/docs/collocation/pages.md
@@ -57,7 +57,8 @@
 		"pageOrientation": "portrait", //横屏配置，全局屏幕旋转设置(仅 APP/微信/QQ小程序)，支持 auto / portrait / landscape
 		"rpxCalcMaxDeviceWidth": 960,
 		"rpxCalcBaseDeviceWidth": 375,
-		"rpxCalcIncludeWidth": 750
+		"rpxCalcIncludeWidth": 750,
+		"ignoreBaseWidth": false
 	},
 	"tabBar": {
 		"color": "#7A7E83",
@@ -240,7 +241,7 @@ uni-app 2.9+ 新增 leftWindow, topWindow, rightWindow 配置。用于解决宽�
 # pages
 
 `uni-app` 通过 pages 节点配置应用由哪些页面组成，pages 节点接收一个数组，数组每个项都是一个对象，其属性值如下：
- 
+
 |属性|类型|默认值|描述|
 |:-|:-|:-|:-|
 |path|String||配置页面路径|
@@ -257,16 +258,16 @@ uni-app 2.9+ 新增 leftWindow, topWindow, rightWindow 配置。用于解决宽�
 开发目录为：
 <pre v-pre="" data-lang="">
 	<code class="lang-" style="padding:0">
-┌─pages               
+┌─pages
 │  ├─index
-│  │  └─index.vue    
+│  │  └─index.vue
 │  └─login
-│     └─login.vue    
-├─static             
-├─main.js       
-├─App.vue          
-├─manifest.json  
-└─pages.json            
+│     └─login.vue
+├─static
+├─main.js
+├─App.vue
+├─manifest.json
+└─pages.json
 	</code>
 </pre>
 
@@ -276,10 +277,10 @@ uni-app 2.9+ 新增 leftWindow, topWindow, rightWindow 配置。用于解决宽�
 {
     "pages": [
         {
-            "path": "pages/index/index", 
+            "path": "pages/index/index",
             "style": { ... }
         }, {
-            "path": "pages/login/login", 
+            "path": "pages/login/login",
             "style": { ... }
         }
     ]
@@ -358,7 +359,7 @@ uni-app 2.9+ 新增 leftWindow, topWindow, rightWindow 配置。用于解决宽�
         </view>
         <view> 状态栏下的文字 </view>
     </view>
-</template>    
+</template>
 <style>
     .status_bar {
         height: var(--status-bar-height);
@@ -378,7 +379,7 @@ uni-app 2.9+ 新增 leftWindow, topWindow, rightWindow 配置。用于解决宽�
 	* titleNView：给原生导航栏提供更多配置，包括自定义按钮、滚动渐变效果、搜索框等，详见[titleNView](/collocation/pages?id=app-titleNView)
 	* subNView：使用nvue原生渲染，所有布局自己开发，具备一切自定义灵活度。详见[subNVue](/collocation/pages?id=app-subNVues)
 - 页面禁用原生导航栏后，想要改变状态栏的前景字体样式，仍可设置页面的 navigationBarTextStyle 属性（只能设置为 black或white）。如果想单独设置状态栏颜色，App端可使用[plus.navigator.setStatusBarStyle](http://www.html5plus.org/doc/zh_cn/navigator.html#plus.navigator.setStatusBarStyle)设置。注意部分低端Android手机（4.4）自身不支持设置状态栏前景色。
- 
+
 鉴于以上问题，在原生导航能解决业务需求的情况下，尽量使用原生导航。甚至有时需要牺牲一些不是很重要的需求。在App和H5下，uni-app提供了灵活的处理方案：[titleNView](/collocation/pages?id=app-titleNView)、[subNVue](/collocation/pages?id=app-subNVues)、或整页使用nvue。但在小程序下，因为其自身的限制，没有太好的方案。有必要的话，也可以用条件编译分端处理。
 
 ### app-plus
@@ -853,7 +854,7 @@ h5 平台下拉刷新动画，只有 circle 类型。
 	export default {
 		data() {
 			return {
-				
+
 			}
 		}
 	}
@@ -1054,7 +1055,7 @@ subPackages 节点接收一个数组，数组每一项都是应用的子包，�
 |root|String|是|子包的根目录|
 |pages|Array|是|子包由哪些页面组成，参数同 [pages](/collocation/pages?id=pages)|
 
-**注意：** 
+**注意：**
 
 - ```subPackages``` 里的pages的路径是 ``root`` 下的相对路径，不是全路径。
 - 微信小程序每个分包的大小是2M，总体积一共不能超过16M。
@@ -1073,24 +1074,24 @@ subPackages 节点接收一个数组，数组每一项都是应用的子包，�
 假设支持分包的 ```uni-app``` 目录结构如下：
 <pre v-pre="" data-lang="">
 	<code class="lang-" style="padding:0">
-┌─pages               
+┌─pages
 │  ├─index
-│  │  └─index.vue    
+│  │  └─index.vue
 │  └─login
-│     └─login.vue    
-├─pagesA   
+│     └─login.vue
+├─pagesA
 │  ├─static
 │  └─list
-│     └─list.vue 
-├─pagesB    
+│     └─list.vue
+├─pagesB
 │  ├─static
 │  └─detail
-│     └─detail.vue  
-├─static             
-├─main.js       
-├─App.vue          
-├─manifest.json  
-└─pages.json            
+│     └─detail.vue
+├─static
+├─main.js
+├─App.vue
+├─manifest.json
+└─pages.json
 	</code>
 </pre>
 
@@ -1131,7 +1132,7 @@ subPackages 节点接收一个数组，数组每一项都是应用的子包，�
 }
 ```
 
-# preloadRule 
+# preloadRule
 
 分包预载配置。
 

--- a/src/core/service/api/base/upx2px.js
+++ b/src/core/service/api/base/upx2px.js
@@ -1,17 +1,21 @@
 const EPS = 1e-4
 const BASE_DEVICE_WIDTH = 750
+const BASE_DEVICE_PAD_WIDTH = 2048
 let isIOS = false
 let deviceWidth = 0
+let deviceHeight = 0
 let deviceDPR = 0
 
 function checkDeviceWidth () {
   const {
     platform,
     pixelRatio,
-    windowWidth
+    windowWidth,
+    windowHeight
   } = uni.getSystemInfoSync()
 
   deviceWidth = windowWidth
+  deviceHeight = windowHeight
   deviceDPR = pixelRatio
   isIOS = platform === 'ios'
 }
@@ -34,9 +38,10 @@ export function upx2px (number, newDeviceWidth) {
   const maxWidth = checkValue(config.rpxCalcMaxDeviceWidth, 960)
   const baseWidth = checkValue(config.rpxCalcBaseDeviceWidth, 375)
   const includeWidth = checkValue(config.rpxCalcIncludeWidth, 750)
+  const ignoreBaseWidth = config.ignoreBaseWidth || false
   let width = newDeviceWidth || deviceWidth
-  width = number === includeWidth || width <= maxWidth ? width : baseWidth
-  let result = (number / BASE_DEVICE_WIDTH) * width
+  width = number === includeWidth || width <= maxWidth || ignoreBaseWidth ? width : baseWidth
+  let result = (number / (width >= maxWidth && deviceWidth > deviceHeight && ignoreBaseWidth ? BASE_DEVICE_PAD_WIDTH : BASE_DEVICE_WIDTH)) * width
   if (result < 0) {
     result = -result
   }


### PR DESCRIPTION
增加`ignoreBaseWidth`属性，用于h5大屏转换时不用固定基准值，而是以2048的设计稿进行换算，仅横屏时有效