### PR TITLE
fix: 修复多分包共用组件仍然提示建议移动的问题

### DIFF
--- a/packages/webpack-uni-mp-loader/lib/plugin/generate-json.js
+++ b/packages/webpack-uni-mp-loader/lib/plugin/generate-json.js
@@ -51,7 +51,7 @@ function analyzeUsingComponents () {
         return false
       }
       pkgs.add(pkgRoot)
-      if (pkgs.length > 1) { // 被多个分包引用
+      if (pkgs.size > 1) { // 被多个分包引用
         return false
       }
     }


### PR DESCRIPTION
一个小 bug，Set 没有 length 方法，这里逻辑永远为 false。

因此当 component 被多个分包引用时这里不会返回，导致控制台依然会产生建议移动到子包的提示：

```
A B 为分包，X 为公共组件，且未被主包引用

仍然提示：自定义组件 X 建议移动到子包 A 内
```

修复后可消除提示