### PR TITLE
remove watch options: ignore node_modules.

### DIFF
--- a/packages/vue-cli-plugin-uni/lib/util.js
+++ b/packages/vue-cli-plugin-uni/lib/util.js
@@ -21,7 +21,6 @@ module.exports = {
   getWatchOptions () {
     return {
       ignored: [
-        /node_modules/,
         path.resolve(process.env.UNI_INPUT_DIR, '*.md'),
         path.resolve(process.env.UNI_INPUT_DIR, '.hbuilderx'),
         path.resolve(process.env.UNI_INPUT_DIR, '.editorconfig'),


### PR DESCRIPTION
Fixes #2760.

解决yarn link和npm link时候，uniapp工程不会自动触发编译问题。