### PR TITLE
扩展自动引入组件的公共路径,用以区分多个入口的应用时， 组件无法共享的问题

### DIFF
--- a/packages/uni-cli-shared/lib/pages.js
+++ b/packages/uni-cli-shared/lib/pages.js
@@ -368,7 +368,9 @@ function getAutoComponentsByDir (componentsPath, absolute = false) {
 
 function initAutoComponents () {
   const allComponents = {}
-  const componentsDirs = [path.resolve(process.env.UNI_INPUT_DIR, 'components')]
+  const dir = path.resolve(process.env.VUE_CLI_CONTEXT || process.cwd(), 'src')
+  const commonDir = fs.existsSync(dir) ? dir : ''
+  const componentsDirs = [path.resolve(process.env.UNI_INPUT_DIR, 'components'), commonDir]
   global.uniModules.forEach(module => {
     componentsDirs.push(path.resolve(process.env.UNI_INPUT_DIR, 'uni_modules', module, 'components'))
   })


### PR DESCRIPTION
扩展自动引入组件的公共路径,用以区分多个入口的应用时， 组件无法共享的问题