### PR TITLE
Enhance externalclasses and add component placeholder

### DIFF
--- a/packages/uni-cli-shared/lib/cache.js
+++ b/packages/uni-cli-shared/lib/cache.js
@@ -193,6 +193,23 @@ function updateComponentGenerics (name, componentGenerics) {
   }
 }
 
+function updateComponentPlaceholder (name, componentPlaceholder) {
+  const oldJsonStr = getJsonFile(name)
+  if (oldJsonStr) { // update
+    const jsonObj = JSON.parse(oldJsonStr)
+    jsonObj.componentPlaceholder = componentPlaceholder
+    const newJsonStr = JSON.stringify(jsonObj, null, 2)
+    if (newJsonStr !== oldJsonStr) {
+      updateJsonFile(name, newJsonStr)
+    }
+  } else { // add
+    const jsonObj = {
+      componentPlaceholder
+    }
+    updateJsonFile(name, jsonObj)
+  }
+}
+
 function updateGenericComponents (name, genericComponents) {
   const oldJsonStr = getJsonFile(name)
   if (oldJsonStr) { // update
@@ -344,6 +361,7 @@ module.exports = {
   updateComponentJson,
   updateSpecialMethods,
   updateUsingComponents,
+  updateComponentPlaceholder,
   updateUsingGlobalComponents,
   updateAppJsonUsingComponents,
   updateUsingAutoImportComponents,

--- a/packages/uni-cli-shared/lib/cache.js
+++ b/packages/uni-cli-shared/lib/cache.js
@@ -90,6 +90,10 @@ function updateComponentJson (name, jsonObj, usingComponents = true, type = 'Com
       if (oldJsonObj.usingGlobalComponents) { // 复制 global components(针对不支持全局 usingComponents 的平台)
         jsonObj.usingGlobalComponents = oldJsonObj.usingGlobalComponents
       }
+      // componentPlaceholder
+      if (oldJsonObj.componentPlaceholder) {
+        jsonObj.componentPlaceholder = oldJsonObj.componentPlaceholder
+      }
     }
     const newJsonStr = JSON.stringify(jsonObj, null, 2)
     if (newJsonStr !== oldJsonStr) {

--- a/packages/webpack-uni-mp-loader/lib/script-new.js
+++ b/packages/webpack-uni-mp-loader/lib/script-new.js
@@ -114,7 +114,7 @@ module.exports = function (content, map) {
     const imported = new Set()
     components.forEach(c => imported.add(getComponentName(hyphenate(c.name))))
     const cs = getAutoComponents(componentPlaceholders.map(p => p.value)
-      .filter(p => !imported.has(p)))
+      .filter(p => !imported.has(p))).map(c => { return { name: c.name, source: c.source } })
     components = (components || []).concat(cs)
   }
 

--- a/packages/webpack-uni-mp-loader/lib/script-new.js
+++ b/packages/webpack-uni-mp-loader/lib/script-new.js
@@ -1,6 +1,7 @@
 const path = require('path')
 
 const parser = require('@babel/parser')
+const babelGenerate = require('@babel/generator').default
 
 const {
   removeExt,
@@ -15,11 +16,13 @@ const {
 } = require('@dcloudio/uni-cli-shared/lib/platform')
 
 const {
+  getAutoComponents,
   isBuiltInComponentPath
 } = require('@dcloudio/uni-cli-shared/lib/pages')
 
 const {
-  updateUsingComponents
+  updateUsingComponents,
+  updateComponentPlaceholder
 } = require('@dcloudio/uni-cli-shared/lib/cache')
 
 const preprocessor = require('@dcloudio/vue-cli-plugin-uni/packages/webpack-preprocess-loader/preprocess')
@@ -77,14 +80,43 @@ module.exports = function (content, map) {
     type = 'Component'
   }
 
-  const {
+  let {
+    ast,
     state: {
-      components
+      components,
+      componentPlaceholders
     }
   } = traverse(parser.parse(content, getBabelParserOptions()), {
     type,
-    components: []
+    components: [],
+    componentPlaceholders: []
   })
+
+  if (componentPlaceholders.length) {
+    // generate js code after remove componentPlaceholder
+    content = babelGenerate(ast, {
+      retainLines: true,
+      decoratorsBeforeExport: true,
+      retainFunctionParens: true,
+      jsescOption: {
+        quotes: 'single'
+      }
+    }, content).code
+    // updateComponentPlaceholder and add easycom's component
+    const componentPlaceholder = Object.create(null)
+    componentPlaceholders.forEach(c => {
+      c.name = getComponentName(hyphenate(c.name))
+      c.value = getComponentName(hyphenate(c.value))
+      componentPlaceholder[c.name] = c.value
+    })
+    updateComponentPlaceholder(resourcePath, componentPlaceholder)
+    // auto components
+    const imported = new Set()
+    components.forEach(c => imported.add(getComponentName(hyphenate(c.name))))
+    const cs = getAutoComponents(componentPlaceholders.map(p => p.value)
+      .filter(p => !imported.has(p)))
+    components = (components || []).concat(cs)
+  }
 
   const callback = this.async()
 

--- a/src/platforms/mp-weixin/runtime/wrapper/component-base-parser.js
+++ b/src/platforms/mp-weixin/runtime/wrapper/component-base-parser.js
@@ -98,8 +98,19 @@ export default function parseBaseComponent (vueComponentOptions, {
     }
   }
   // externalClasses
-  if (vueOptions.externalClasses) {
-    componentOptions.externalClasses = vueOptions.externalClasses
+  const externalClasses = new Set()
+  let p = VueComponent
+  do {
+    const ex = p.options.externalClasses
+    if (Array.isArray(ex)) {
+      ex.forEach(c => externalClasses.add(c))
+    } else if (typeof cs === 'string') {
+      externalClasses.add(ex)
+    }
+    p = p.super
+  } while (p)
+  if (externalClasses.size > 0) {
+    componentOptions.externalClasses = Array.from(externalClasses)
   }
 
   if (Array.isArray(vueOptions.wxsCallMethods)) {


### PR DESCRIPTION
1. 在#1383 的基础上优化externalclasses， 支持合并父类的externalclasses配置，有助于开发UI库和减少小程序包尺寸。

2. 支持微信小程序分包异步化，参考#2934，同时整合了easycom生态。

```typescript
@Component({
  componentPlaceholder: {
    'pkg-test-hello': 'iox-skeleton'
  }
})
export default class Apps extends Vue {
}
```
或者
```typescript
Vue.extend({
  componentPlaceholder: {
    'pkg-test-hello': 'iox-skeleton'
  }
});
```

在`componentPlaceholder`配置中:
- `pkg-test-hello`也可以写成驼峰模式`pkgTestHello`
- `iox-skeleton`也可以写成驼峰模式`ioxSkeleton`
- `iox-skeleton`还可以是标准的微信组件，比如`view`
- `iox-skeleton`还可以是直接import的组件名字，比如`skeleton`，类似components的配置。

>如果引入的`iox-skeleton`符合easycom的形式，而组件模版并未使用其标签，也会自动引入到usingComponents配置中。

其中types定义为：
```typescript
declare module 'vue/types/options' {
  interface ComponentOptions<V extends Vue> {
    externalClasses?: string | string[];
    componentPlaceholder?: {[name: string]: string | typeof Vue};
  }
}
```