### PR TITLE
enhance tree shaking for ESM  module when split chunks.

### DIFF
--- a/packages/vue-cli-plugin-uni/lib/split-chunks.js
+++ b/packages/vue-cli-plugin-uni/lib/split-chunks.js
@@ -180,8 +180,10 @@ module.exports = function getSplitChunks () {
               }
               return true
             }
-          } else {
-            return hasMainPackageComponent(m.module, subPackageRoot)
+          } else if (m.dependency && m.dependency.getReference()) {
+            if (hasMainPackageComponent(m.module, subPackageRoot)) {
+              return true
+            }
           }
         }
       }


### PR DESCRIPTION
当进行分包优化时候，对Tree shaking进行进一步分析，把分包间接引入的模块拆分到分包中。
比如：
1. 小程序有PA、PB两个分包
2. 引入ESM依赖包A
3. A包中有a, b, c三个模块
4. 其中A.c被主包页面引入使用，A.a被分包PA使用，A.b被分包PB使用
5. 优化前a, b, c三个模块均会被打包到主包的vender.js中。
6. 优化后c被打包到主包，a被打包到PA包，b被打包到PB包。

参考测试项目：https://github.com/huadong/weapp-subpackages-optimization