### PR TITLE
fix: 修复编译到钉钉平台getStorageSync报查无此key

### DIFF
--- a/packages/uni-mp-alipay/dist/index.js
+++ b/packages/uni-mp-alipay/dist/index.js
@@ -624,9 +624,13 @@ function setStorageSync (key, data) {
   })
 }
 function getStorageSync (key) {
-  const result = my.getStorageSync({
-    key
-  });
+  let result = { data: null }
+  try {
+    result = my.getStorageSync({
+      key
+    });
+  } catch (error) {
+  }
   // 支付宝平台会返回一个 success 值，但是目前测试的结果这个始终是 true。当没有存储数据的时候，其它平台会返回空字符串。
   return result.data !== null ? result.data : ''
 }


### PR DESCRIPTION
uni.getStorageSync编译到钉钉小程序，在不存在key对应的storage的情况下会报查无此key的错误，增加对这种情况的异常处理，避免影响渲染