### PR TITLE
feat(cli): 支持doExpressions和pipelineOperator语法解析

### DIFF
--- a/packages/uni-cli-shared/lib/platform.js
+++ b/packages/uni-cli-shared/lib/platform.js
@@ -137,6 +137,8 @@ module.exports = {
     return {
       sourceType: 'module',
       plugins: [
+        ['pipelineOperator', { proposal: 'minimal' }],
+        'doExpressions',
         'optionalChaining',
         'typescript',
         ['decorators', {


### PR DESCRIPTION
存在很久的bug https://github.com/dcloudio/uni-app/issues/1660
babel.config.js配置了一些自定义的Babel插件，但是使用起来还是会报错，原因因该是二次调用Babel插件的时候写死了plugins
目前的解决方案是添加了比较常用的doExpressions和pipelineOperator