### PR TITLE
fix(webpack-uni-app-loader): 部分平台无法识别不以 . 开头的相对路径

### DIFF
--- a/packages/webpack-uni-mp-loader/lib/plugin/index-new.js
+++ b/packages/webpack-uni-mp-loader/lib/plugin/index-new.js
@@ -47,9 +47,11 @@ function addSubPackagesRequire (compilation) {
           name.indexOf(root + '/') === 0 &&
           name !== subPackageVendorPath
         ) {
-          const source =
-            `require('${normalizePath(path.relative(path.dirname(name), subPackageVendorPath))}');` +
-            compilation.assets[name].source()
+          let relativePath = normalizePath(path.relative(path.dirname(name), subPackageVendorPath))
+          if (!relativePath.startsWith('.')) {
+            relativePath = './' + relativePath
+          }
+          const source = `require('${relativePath}');` + compilation.assets[name].source()
 
           compilation.assets[name] = {
             size () {


### PR DESCRIPTION
修复：支付宝小程序报错：Module not found: Error: Can't resolve 'common/vendor.js'

支付宝require 无法将 common/vendor.js 识别为 ./common/vendor.js。

详见issue：https://github.com/dcloudio/uni-app/issues/3059