### PR TITLE
feat: 支持头条小程序在开发阶段使用 sourceMap file 形式

### DIFF
--- a/packages/vue-cli-plugin-uni/lib/configure-webpack.js
+++ b/packages/vue-cli-plugin-uni/lib/configure-webpack.js
@@ -283,7 +283,7 @@ module.exports = function configureWebpack (platformOptions, manifestPlatformOpt
         process.env.UNI_PLATFORM !== 'mp-alipay' &&
         process.env.UNI_PLATFORM !== 'quickapp-webview' // 目前 ov 的开发工具支持 eval 模式
       ) {
-        plugins.push(sourceMap.createSourceMapDevToolPlugin(process.env.UNI_PLATFORM === 'mp-weixin'))
+        plugins.push(sourceMap.createSourceMapDevToolPlugin(process.env.UNI_PLATFORM === 'mp-weixin' || process.env.UNI_PLATFORM === 'mp-toutiao'))
       }
     }
 


### PR DESCRIPTION
当前仅有 微信小程序的代码 在开发阶段会以 sourceMap 文件的形式构建，其他小程序平台基本都是 inline-source-map 的形式。

由于头条小程序开发的时候，转译体积明显比 微信的小程序产物要大，因此同一份代码在微信开发者工具中能够正常上传，在头条小程序开发者工具中就不能上传了。

所以增加对 头条小程序 的支持，使得 sourcMap 产物也是 文件形式，而不是内联的。

> 进一步可以考虑对所有平台使用同样的策略，待讨论。