### PR TITLE
fix:修正package.json配置自定义编译条件覆盖为false

### DIFF
--- a/packages/uni-cli-shared/lib/package.js
+++ b/packages/uni-cli-shared/lib/package.js
@@ -35,7 +35,9 @@ module.exports = {
         if (scriptName !== name) {
           const define = uniAppOptions.scripts[scriptName].define
           Object.keys(define).forEach(name => {
-            define[name] = false
+            if (typeof scriptOptions.define[name] === "undefined") {
+              define[name] = false
+            }
           })
           Object.assign(scriptOptions.define, define)
         }


### PR DESCRIPTION
如果有package.json下的uni-app->scripts配置有两个平台以上且有相同的自定义编译条件变量时会导致变量覆盖为false