### PR TITLE
兼容快手小程序担保支付（ks.pay），原 H5 支付 (ks.requestPayment） 废弃。

### DIFF
--- a/packages/uni-mp-kuaishou/dist/index.js
+++ b/packages/uni-mp-kuaishou/dist/index.js
@@ -697,7 +697,10 @@ const protocols = {
   previewImage,
   getSystemInfo,
   getSystemInfoSync: getSystemInfo,
-  getUserProfile
+  getUserProfile,
+  requestPayment: {
+    name: ks.pay ? 'pay' : 'requestPayment'
+  }
 };
 const todos = [
   'vibrate'

--- a/src/platforms/mp-kuaishou/runtime/api/protocols.js
+++ b/src/platforms/mp-kuaishou/runtime/api/protocols.js
@@ -10,7 +10,10 @@ export const protocols = {
   previewImage,
   getSystemInfo,
   getSystemInfoSync: getSystemInfo,
-  getUserProfile
+  getUserProfile,
+  requestPayment: {
+    name: ks.pay ? 'pay' : 'requestPayment'
+  }
 }
 export const todos = [
   'vibrate'


### PR DESCRIPTION
兼容快手小程序担保支付（ks.pay），原 H5 支付 (ks.requestPayment） 废弃。
参考文档： https://mp.kuaishou.com/docs/develop/api-next/open/payment/ks.pay.html

开发者需要注意：快手担保支付增加参数 serviceId 固定值为 '1' (字符串格式)。