### PR TITLE
fix(小程序插件): 小程序插件 main.js 文件中导出的函数位置调整

### DIFF
--- a/packages/webpack-uni-mp-loader/lib/plugin/index-new.js
+++ b/packages/webpack-uni-mp-loader/lib/plugin/index-new.js
@@ -85,7 +85,7 @@ function addMPPluginRequire (compilation) {
       const source =
         orignalSource.substring(0, newlineIndex) +
         orignalSource.substring(newlineIndex + 1) +
-          `\nmodule.exports = ${globalEnv}.__webpack_require_UNI_MP_PLUGIN__('${uniModuleId}');\n`
+        `\nmodule.exports = ${globalEnv}.__webpack_require_UNI_MP_PLUGIN__('${uniModuleId}');\n`
 
       compilation.assets[name] = {
         size () {


### PR DESCRIPTION
[](https://user-images.githubusercontent.com/22534346/157244087-e1c2dd02-b6ac-499b-a2bd-d06716c628dd.png)[](https://user-images.githubusercontent.com/22534346/157244198-860f9eb2-87a4-4a3e-a0ad-216ff11576a3.png)支付宝小程序修改前编译 main.js 结果：
image

修改后：
image

支付宝小程序插件，默认编译报错，需要单独导出和外部通信的文件。

微信小程序不受本次代码的影响，微信端的编译和修改后的一致。

示例项目：https://github.com/Yaob1990/uni-plugin-template