### PR TITLE
fix(h5): incorrect image src attribute value if URL contains space character (#3399)

### DIFF
--- a/src/core/view/components/rich-text/html-parser.js
+++ b/src/core/view/components/rich-text/html-parser.js
@@ -7,12 +7,12 @@ function removeDOCTYPE (html) {
     .replace(/<!DOCTYPE.*>\n/, '')
 }
 
-function parseAttrs (attrs) {
+function parseAttrs (attrs, tag) {
   return attrs.reduce(function (pre, attr) {
     let value = attr.value
     const name = attr.name
 
-    if (value.match(/ /) && name !== 'style') {
+    if (tag !== 'img' && name !== 'src' && value.match(/ /) && name !== 'style') {
       value = value.split(' ')
     }
 
@@ -45,7 +45,7 @@ export default function parseHtml (html) {
         name: tag
       }
       if (attrs.length !== 0) {
-        node.attrs = parseAttrs(attrs)
+        node.attrs = parseAttrs(attrs, tag)
       }
       if (unary) {
         const parent = stacks[0] || results


### PR DESCRIPTION
不确定为什么需要这个逻辑，为了不影响其他情况，所以只针对 `img.src` 处理了一下。

详细问题见 https://github.com/dcloudio/uni-app/issues/3399
