### PR TITLE
fix: 解决同一时刻发送多个jsonp请求，仅有一个请求会正常执行callback的问题

### DIFF
--- a/src/platforms/h5/helpers/get-jsonp.js
+++ b/src/platforms/h5/helpers/get-jsonp.js
@@ -8,7 +8,7 @@
 export function getJSONP (url, options, success, error) {
   var js = document.createElement('script')
   var callbackKey = options.callback || 'callback'
-  var callbackName = '__callback' + Date.now()
+  var callbackName = '__callback' + Date.now() + Math.random().toString().slice(2)
   var timeout = options.timeout || 30000
   var timing
   function end () {


### PR DESCRIPTION
[#3681](https://github.com/dcloudio/uni-app/issues/3681)