### PR TITLE
fix: css assets add config.base

### DIFF
--- a/packages/uni-cli-shared/src/vite/plugins/vitejs/plugins/css.ts
+++ b/packages/uni-cli-shared/src/vite/plugins/vitejs/plugins/css.ts
@@ -292,6 +292,9 @@ export function cssPostPlugin(
       ) => {
         // replace asset url references with resolved url.
         css = css.replace(assetUrlRE, (_, fileHash, postfix = '') => {
+          if (config.base !== '/') {
+            return config.base + getAssetFilename(fileHash, config) + postfix
+          }
           return normalizePath(
             path.relative(
               path.dirname(filename),


### PR DESCRIPTION
问题描述
build 后 img使用的图片使用了config.base, css中引用的静态资源没有使用config.base

预期结果
config.base 非默认值的时
build 后 img与css中引用的资源均使用config.base

(#4011)