### PR TITLE
fix(h5):mediaQueryList.addEventListener undefined

### DIFF
--- a/packages/uni-h5/src/framework/setup/index.ts
+++ b/packages/uni-h5/src/framework/setup/index.ts
@@ -259,11 +259,16 @@ function onThemeChange() {
   } catch (error) {}
 
   if (mediaQueryList) {
-    mediaQueryList.addEventListener('change', (e) => {
+    let callback = (e: MediaQueryListEvent) => {
       UniServiceJSBridge.emit(ON_THEME_CHANGE, {
         theme: e.matches ? 'dark' : 'light',
       })
-    })
+    }
+    if (mediaQueryList.addEventListener) {
+      mediaQueryList.addEventListener('change', callback)
+    } else {
+      mediaQueryList.addListener(callback)
+    }
   }
 }
 function invokeOnTabItemTap(


### PR DESCRIPTION
有的老版本浏览器只有MediaQueryList.addListener方法，没有addEventListener方法。
需做兼容处理。