### PR TITLE
fix(mp-kuaishou): 兼容快手小程序下eventsync类型判断，使requestSubscribeMessage方法可以正常使用

### DIFF
--- a/packages/uni-mp-vue/dist/vue.runtime.esm.js
+++ b/packages/uni-mp-vue/dist/vue.runtime.esm.js
@@ -5707,7 +5707,7 @@ function createInvoker(initialValue, instance) {
         const eventTarget = e.target;
         const eventSync = eventTarget
             ? eventTarget.dataset
-                ? eventTarget.dataset.eventsync === 'true'
+                ? String(eventTarget.dataset.eventsync) === 'true'
                 : false
             : false;
         if (bubbles.includes(e.type) && !eventSync) {


### PR DESCRIPTION
由于在快手小程序内data-eventsync="true"的值会被转译成Boolean类型，所以快手小程序组件内即使使用了data-eventsync="true"也无法调用requestSubscribeMessage消息模板。
所以在判断对比eventsync值的时候先强制将dataset.eventsync转成String类型。