### PR TITLE
fix(h5): wrong version check for copyWebpackPlugin

### DIFF
--- a/lib/h5/uni.config.js
+++ b/lib/h5/uni.config.js
@@ -30,7 +30,7 @@ function getIndexCssPath (assetsDir, template, hashKey) {
     try {
       const templateContent = fs.readFileSync(getTemplatePath(template))
       if (new RegExp('\\b' + hashKey + '\\b').test(templateContent)) {
-        return path.join(assetsDir, `[name].${VUE_APP_INDEX_CSS_HASH}${CopyWebpackPluginVersion > 5 ? '' : '.'}[ext]`)
+        return path.join(assetsDir, `[name].${VUE_APP_INDEX_CSS_HASH}${CopyWebpackPluginVersion > 7 ? '' : '.'}[ext]`)
       }
     } catch (e) { }
   }


### PR DESCRIPTION
copyWebpackPlugin的[ext]包含dot是从v8后开始的，可见下面的changelog，我这边测试v6.4.1版本[ext]还是不包含dot的，会出现uni-h5的css文件没后缀的情况:
https://github.com/webpack-contrib/copy-webpack-plugin/blob/master/CHANGELOG.md#-breaking-changes-3