### PR TITLE
fix: 补丁默认数据类型错误

### DIFF
--- a/src/platforms/app-plus/view/framework/plugins/vdom-sync.js
+++ b/src/platforms/app-plus/view/framework/plugins/vdom-sync.js
@@ -50,11 +50,7 @@ export class VDomSync {
     vm._$id = generateId(vm, findParent(vm), this.version)
     let vData = this.addBatchVData[vm._$id]
     if (!vData) {
-      console.error('cid unmatched', vm)
-      vData = {
-        data: {},
-        options: {}
-      }
+      vData = [{}, {}]
     } else {
       delete this.addBatchVData[vm._$id]
     }


### PR DESCRIPTION
报错信息:
```bash
TypeError: Invalid attempt to destructure non-iterable instance.
In order to be iterable, non-array objects must have a [Symbol.iterator]() method.
```

在`initVm`初始化时, updateBatchVData根据_$id查询时如果不存在, 给的是 `vData = { data: {}, options: {} }`
但在`addVData`, 和`updateVData`调用时是给的`[data, options]`
所以 调用 `_slicedToArray(vData)`方法时, 报迭代错误.