### PR TITLE
fix(mp-weixin): 避免异步组件加载前获取$refs异常

### DIFF
--- a/src/platforms/mp-weixin/runtime/wrapper/util.js
+++ b/src/platforms/mp-weixin/runtime/wrapper/util.js
@@ -36,13 +36,13 @@ export function initRelation (detail) {
 }
 
 function selectAllComponents (mpInstance, selector, $refs) {
-  const components = mpInstance.selectAllComponents(selector) || []
+  const components = (mpInstance.selectAllComponents(selector) || []).filter(Boolean)
   components.forEach(component => {
     const ref = component.dataset.ref
     $refs[ref] = component.$vm || toSkip(component)
     if (__PLATFORM__ === 'mp-weixin') {
       if (component.dataset.vueGeneric === 'scoped') {
-        component.selectAllComponents('.scoped-ref').forEach(scopedComponent => {
+        (component.selectAllComponents('.scoped-ref') || []).filter(Boolean).forEach(scopedComponent => {
           selectAllComponents(scopedComponent, selector, $refs)
         })
       }
@@ -76,7 +76,7 @@ export function initRefs (vm) {
       const $refs = {}
       selectAllComponents(mpInstance, '.vue-ref', $refs)
       // TODO 暂不考虑 for 中的 scoped
-      const forComponents = mpInstance.selectAllComponents('.vue-ref-in-for') || []
+      const forComponents = (mpInstance.selectAllComponents('.vue-ref-in-for') || []).filter(Boolean)
       forComponents.forEach(component => {
         const ref = component.dataset.ref
         if (!$refs[ref]) {


### PR DESCRIPTION
原因： 内置组件(view等)定义 ref="xxx" 时，selectAllComponents() 返回了 [null] ， JS异常。

使用异步组件时，有时使用 view 做placeHolder组件 