### PR TITLE
fix(H5): 调整uni.showToast提示文本自动换行的处理方法

### DIFF
--- a/src/platforms/h5/components/app/popup/toast.vue
+++ b/src/platforms/h5/components/app/popup/toast.vue
@@ -130,7 +130,7 @@ uni-toast .uni-simple-toast__text {
   font-size: 13px;
   text-align: center;
   max-width: 100%;
-  word-break: break-all;
+  word-break: break-word;
   white-space: normal;
 }
 


### PR DESCRIPTION
原本的样式会使得英文文本换行异常：
![QQ截图20230608111003](https://github.com/dcloudio/uni-app/assets/49092777/be5f86ea-a054-4029-abf7-c42b2143998d)
修改后换行正常：
![QQ截图20230608111022](https://github.com/dcloudio/uni-app/assets/49092777/90475bcb-bc87-4f32-b89a-9b29190c7613)


