### PR TITLE
fix(uni-mp-alipay): 支付宝小程序作为钉钉小程序使用时a:for中的元素绑定变量存在作用域问题

### DIFF
--- a/packages/uni-mp-compiler/src/transforms/utils.ts
+++ b/packages/uni-mp-compiler/src/transforms/utils.ts
@@ -147,7 +147,8 @@ export function rewriteExpression(
     }
   }
 
-  referencedScope = referencedScope || findReferencedScope(babelNode, scope)
+  // 钉钉小程序 a:for 绑定变量存在作用域问题
+  referencedScope = referencedScope || findReferencedScope(babelNode, scope, process.env.UNI_UTS_PLATFORM !== 'mp-dingtalk')
   const id = referencedScope!.id.next()
   if (property) {
     referencedScope!.properties.push(objectProperty(identifier(id), babelNode!))


### PR DESCRIPTION

<img width="1680" alt="image" src="https://github.com/dcloudio/uni-app/assets/101238421/3b9777d6-e80b-41c7-8ba7-6aa8ae900e5c">


## 这里变量a的值未在渲染列表中渲染