### PR TITLE
fix: webpack-uni-mp-loader should support nested node_modules

### DIFF
--- a/packages/webpack-uni-mp-loader/lib/shared.js
+++ b/packages/webpack-uni-mp-loader/lib/shared.js
@@ -36,9 +36,9 @@ function resolve (source) {
 
 function restoreNodeModules (str) {
   if (process.env.UNI_PLATFORM === 'mp-alipay') {
-    str = str.replace('node-modules/npm-scope-', 'node-modules/@')
+    str = str.replaceAll('node-modules/npm-scope-', 'node-modules/@')
   }
-  str = str.replace('node-modules', 'node_modules')
+  str = str.replaceAll('node-modules', 'node_modules')
   return str
 }
 


### PR DESCRIPTION
When `webpack-uni-mp-loader` call `restoreNodeModules` to restore the `modulePath`, it should support nested `node_modules` folder structure. e.g:

mp-alipay
|-- **node-modules**  _<-- first one_
&emsp;&emsp;|-- npm-scope-ali
&emsp;&emsp;&emsp;&emsp;|-- ui-uniapp
&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;|-- **node-modules**  _<-- another nested one_
&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;|-- @ali
&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;|-- primitive-uniapp

### Before fixed: 
`restoreNodeModules`  returns: "node_modules/@ali/ui-uniapp/**node-modules**/@ali/primitive-uniapp"
 (ATTENTION to the second `node-modules`, it should be `node_modules`)

### After fixed: 
`restoreNodeModules`  returns: "node_modules/@ali/ui-uniapp/**node_modules**/@ali/primitive-uniapp"
 (ATTENTION to the second `node_modules`, it is correct now)
