### PR TITLE
fix: adpat donut

### DIFF
--- a/packages/uni-mp-weixin/dist/wx.js
+++ b/packages/uni-mp-weixin/dist/wx.js
@@ -8,6 +8,7 @@ const objectKeys = [
   'serviceMarket',
   'router',
   'worklet',
+  'miniapp',
   '__webpack_require_UNI_MP_PLUGIN__'
 ]
 const singlePageDisableKey = [


### PR DESCRIPTION
uniapp编译出的小程序在腾讯官方多端框架donut上无法正常运行，请参考下面这个帖子：
https://developers.weixin.qq.com/community/develop/article/doc/0006443dd1c0a807a40068ca961c13?idescene=6