### PR TITLE
feat(mp): support for adding plugins to miniprogram components

### DIFF
--- a/packages/uni-mp-vite/src/plugins/entry.ts
+++ b/packages/uni-mp-vite/src/plugins/entry.ts
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import path from 'path'
 import {
   addMiniProgramComponentJson,
@@ -6,6 +7,7 @@ import {
   removeExt,
   encodeBase64Url,
   decodeBase64Url,
+  parseJson,
 } from '@dcloudio/uni-cli-shared'
 import { Plugin } from 'vite'
 
@@ -35,6 +37,15 @@ export function isUniPageUrl(id: string) {
 
 export function isUniComponentUrl(id: string) {
   return id.startsWith(uniComponentPrefix)
+}
+
+export function parseComponentJson(filepath: string) {
+  const jsonPath = filepath.replace(/\.[^.]+$/, '.json')
+  if (fs.existsSync(jsonPath)) {
+    const json = parseJson(fs.readFileSync(jsonPath, 'utf8'))
+
+    return json[process.env.UNI_PLATFORM]
+  }
 }
 
 export function uniEntryPlugin({
@@ -72,6 +83,7 @@ ${global}.createPage(MiniProgramPage)`,
               process.env.UNI_PLATFORM === 'mp-baidu'
                 ? 'apply-shared'
                 : undefined,
+            ...parseComponentJson(filepath),
           }
         )
         return {


### PR DESCRIPTION
加强小程序插件的使用 [https://uniapp.dcloud.net.cn/tutorial/mp-weixin-plugin.html](https://uniapp.dcloud.net.cn/tutorial/mp-weixin-plugin.html)

使其不仅仅能在页面级别的文件中使用，还可以在单个组件中使用。

使用方法：在组件同级目录创建同名json，json内容和 manifest.json 中一致

例子：
- src
  - components
    - hello-word.vue
    - hello-word.json


hello-word.json 内容
```json
{
  "component": true,
  "mp-weixin":  {
    "usingComponents": {
      "cell": "plugin://contactPlugin/cell"
    }
  },
  "mp-baidu": {
    "usingSwanComponents": {
      "chart": "dynamicLib://echartsLib/chart"
    }
  }
}
```