### PR TITLE
feat(uni-mp-compiler): 对具名插槽 name 包含短横线的边缘情况进行处理

### DIFF
--- a/packages/uni-mp-compiler/__tests__/slot.spec.ts
+++ b/packages/uni-mp-compiler/__tests__/slot.spec.ts
@@ -65,6 +65,16 @@ describe('compiler: transform slot', () => {
 }`
     )
   })
+  test('names slots with fallback content 带横线', () => {
+    assert(
+      `<button><slot name="text-name">Submit</slot></button>`,
+      `<button><block wx:if="{{$slots['text-name']}}"><slot name="text-name"></slot></block><block wx:else>Submit</block></button>`,
+      `(_ctx, _cache) => {
+  return {}
+}`
+    )
+  })
+
   test('names slots with fallback content', () => {
     assert(
       `<button><slot name="text">Submit</slot></button>`,

--- a/packages/uni-mp-compiler/src/template/codegen.ts
+++ b/packages/uni-mp-compiler/src/template/codegen.ts
@@ -187,7 +187,11 @@ function genSlot(node: SlotOutletNode, context: TemplateCodegenContext) {
       }
     }
   }
-  genVIf(`$slots.${name}`, context)
+  if (name.includes('-')) {
+    genVIf(`$slots['${name}']`, context)
+  } else {
+    genVIf(`$slots.${name}`, context)
+  }
   push(`>`)
   genElement(node, context)
   push(`</block>`)


### PR DESCRIPTION
原本 `<slot name='text-name'>占位符</slot>` 会编译成

```js
<block wx:if="{{$slots.text-name}}">
  <slot name="text-name"></slot>
</block>
<block wx:else>Submit</block>
```
js 对象的属性中，访问带横线的属性，不能通过 `.` 直接访问，需要使用 `['a-b']` 包裹

这里对这种异常情况进行兼容，补充了对应的单元测试
