### PR TITLE
fix: 【发行为混合分包】TypeError: t.$callHook is not a function

### DIFF
--- a/packages/uni-mp-core/src/runtime/app.ts
+++ b/packages/uni-mp-core/src/runtime/app.ts
@@ -113,6 +113,8 @@ export function initCreateSubpackageApp(parseAppOptions?: ParseAppOptions) {
       })
     if (!app) return
     ;(vm.$ as any).ctx.$scope = app
+    (vm.$ as any).ctx.$hasHook = hasHook
+    (vm.$ as any).ctx.$callHook = callHook
     const globalData = app.globalData
     if (globalData) {
       Object.keys(appOptions.globalData).forEach((name) => {


### PR DESCRIPTION
#4781 

1. 当发行为混合分包的时候，uniapp 会调用 initCreateSubpackageApp 方法

2. initCreateSubpackageApp 里调用 parseApp ，并在 onLaunch 时候进行 initBaseInstance

3. initCreateSubpackageApp 里调用 parseApp 后同步执行 `vm.$.ctx.$scope = app;`

4. initBaseInstance 在 onLaunch 会进行 `if (this.$vm && ctx.$scope) {return;}` 阻断，如果通过则执行 `ctx.$hasHook = hasHook;  ctx.$callHook = callHook;` 

问题出在 onLaunch 是异步的，导致 4 的流程阻断，没有执行 $callHook 赋值，最终导致 `initAppLifecycle` 中的 `vm.$callHook` 为 undefined