### PR TITLE
fix(web): 修复 uni.showActionSheet 的参数 popover.width 设置无效的问题 (question/189745)

### DIFF
--- a/packages/uni-h5/src/helpers/usePopupStyle.ts
+++ b/packages/uni-h5/src/helpers/usePopupStyle.ts
@@ -14,6 +14,7 @@ export type popupStyleType = {
     left: string
     top: string
     bottom: string
+    width?: string
   }
   triangle: {
     'border-width': string
@@ -24,7 +25,7 @@ export type popupStyleType = {
   }
 }
 
-export function usePopupStyle(props: Data) {
+export function usePopupStyle(props: Data, dynamicWidth = false) {
   const popupWidth = ref(0)
   const popupHeight = ref(0)
 
@@ -62,15 +63,22 @@ export function usePopupStyle(props: Data) {
         'border-style': 'solid',
       })
       const popoverLeft = getNumber(popover.left)
-      const popoverWidth = getNumber(popover.width)
+      const defaultWidth = 300
+      const popoverWidth = getNumber(
+        popover.width ? popover.width : defaultWidth
+      )
       const popoverTop = getNumber(popover.top)
       const popoverHeight = getNumber(popover.height)
+      const layerWidth = dynamicWidth ? popoverWidth : defaultWidth
       const center = popoverLeft + popoverWidth / 2
       contentStyle.transform = 'none !important'
-      const contentLeft = Math.max(0, center - 300 / 2)
+      const contentLeft = Math.max(0, center - layerWidth / 2)
       contentStyle.left = `${contentLeft}px`
+      if (dynamicWidth) {
+        contentStyle.width = `${layerWidth}px`
+      }
       let triangleLeft = Math.max(12, center - contentLeft)
-      triangleLeft = Math.min(300 - 12, triangleLeft)
+      triangleLeft = Math.min(layerWidth - 12, triangleLeft)
       triangleStyle.left = `${triangleLeft}px`
       const vcl = popupHeight.value / 2
       if (popoverTop + popoverHeight - vcl > vcl - popoverTop) {

--- a/packages/uni-h5/src/service/api/ui/popup/actionSheet.tsx
+++ b/packages/uni-h5/src/service/api/ui/popup/actionSheet.tsx
@@ -109,7 +109,7 @@ export default /*#__PURE__*/ defineComponent({
     const main: Ref<HTMLElement | null> = ref(null)
     const { t } = useI18n()
     const { _close } = useActionSheetLoader(props, emit as SetupContext['emit'])
-    const { popupStyle } = usePopupStyle(props)
+    const { popupStyle } = usePopupStyle(props, true)
 
     let scroller: Scroller
 


### PR DESCRIPTION
popover 参数仅在 web pc 端有效，此前 popover.width 设置参数无效，并且 popover.left 参数 设置与实际值有偏差（差150px），三角形位置也可能不对，本次提交修复了这三个问题。
主要修改了 usePopupStyle 方法，此方法除了 uni.showActionSheet 用到还有 picker 组件用到，所以 在此方法加了第二个参数判断是否是动态宽度，picker组件依然固定宽度300px，不影响 picker 组件功能