### PR TITLE
fix(mp-weixin): 回退微信小程序对 span 的忽略处理

### DIFF
--- a/packages/uni-template-compiler/lib/mp.js
+++ b/packages/uni-template-compiler/lib/mp.js
@@ -110,7 +110,7 @@ const tags = {
     'open-container',
     'share-element',
     'snapshot',
-    'span',
+    // 'span', // todo: 临时移除 span 的支持，后续判断 skyline 环境进行区分 ask 190418
     'sticky-header',
     'sticky-section'
   ],


### PR DESCRIPTION
#190418