### PR TITLE
fix: 修复 使用了三方插件时，用 HBuilderX 发行打包 easycom 不生效的问题

### DIFF
--- a/packages/vite-plugin-uni/src/cli/action.ts
+++ b/packages/vite-plugin-uni/src/cli/action.ts
@@ -139,6 +139,7 @@ export async function runDev(options: CliOptions & ServerOptions) {
 
 export async function runBuild(options: CliOptions & BuildOptions) {
   initEnv('build', options)
+  initEasycom()
   if (
     process.env.UNI_APP_X === 'true' &&
     process.env.UNI_UTS_PLATFORM === 'app-android'


### PR DESCRIPTION
开发微信小程序的时候，在项目下的 vite.config 里使用了 @dcloudio/vite-plugin-uni 插件时，开发运行没有问题，但是发行打包时 easycom 会不生效，easycom 里的组件不会打包到项目里，原因分析如下：

initEasycom 是在项目下的 vite.config 运行的

而 HBuilderX下的  @dcloudio/vite-plugin-uni  读取不到它的值

https://github.com/dcloudio/uni-app/blob/7ea7d03b75109e87482a28f3ac9407a7232bcec9/packages/uni-cli-shared/src/easycom.ts#L190

所以此时 hasEasycom 还是 false，直接返回了：

https://github.com/dcloudio/uni-app/blob/7ea7d03b75109e87482a28f3ac9407a7232bcec9/packages/uni-cli-shared/src/easycom.ts#L191

导致 source 没有值，未定义：

https://github.com/dcloudio/uni-app/blob/7ea7d03b75109e87482a28f3ac9407a7232bcec9/packages/uni-mp-compiler/src/codegen.ts#L221