### PR TITLE
fix: uni-app/x 非小程序平台支持 setTabbarStyle 传递任意颜色

### DIFF
--- a/packages/uni-api/src/protocols/ui/tabBar.ts
+++ b/packages/uni-api/src/protocols/ui/tabBar.ts
@@ -70,11 +70,8 @@ export const SetTabBarStyleOptions: ApiOptions<API_TYPE_SET_TAB_BAR_STYLE> = {
         params.backgroundImage = getRealPath(value)
       }
     },
-    borderStyle(value, params) {
-      if (value) {
-        params.borderStyle = value === 'white' ? 'white' : 'black'
-      }
-    },
+    // 移除 format borderStyle，只在小程序有黑白限制，uni-app/x 允许自定义颜色
+    // borderStyle(value, params) {},
   },
 }
 export const API_HIDE_TAB_BAR = 'hideTabBar'


### PR DESCRIPTION
```js
export function getBorderStyle(borderStyle: string): string {
  const value = BORDER_COLORS.get(borderStyle)
  return value ?? borderStyle
}
```

当用户传递 black/white 时候，会首先查询 BORDER_COLORS 映射为半透明引用，找不到时候使用用户提供的