### PR TITLE
支持自定义 template.transformAssetUrls

### DIFF
--- a/packages/vite-plugin-uni/src/vue/options.ts
+++ b/packages/vite-plugin-uni/src/vue/options.ts
@@ -136,11 +136,12 @@ export function initPluginVueOptions(
     createUniVueTransformAssetUrls(
       isExternalUrl(options.base) ? options.base : ''
     )
-  templateOptions.transformAssetUrls = builtInTransformAssetUrls
 
   // 用户传递配置 eg: transformAssetUrls.tags = {'my-image': ['src']}
   // docs: https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue
   const userOptionsTransformAssetUrls = templateOptions.transformAssetUrls
+
+  templateOptions.transformAssetUrls = builtInTransformAssetUrls
   if (
     typeof userOptionsTransformAssetUrls !== 'boolean' &&
     !!userOptionsTransformAssetUrls?.tags &&

--- a/packages/vite-plugin-uni/src/vue/options.ts
+++ b/packages/vite-plugin-uni/src/vue/options.ts
@@ -128,15 +128,20 @@ export function initPluginVueOptions(
   if (!compilerOptions.nodeTransforms) {
     compilerOptions.nodeTransforms = []
   }
-  if (options.platform === 'h5' || options.platform === 'web') {
-    templateOptions.transformAssetUrls = createUniVueTransformAssetUrls(
-      isExternalUrl(options.base) ? options.base : ''
-    )
-  } else {
-    // 替换内置的 transformAssetUrls 逻辑
-    templateOptions.transformAssetUrls = {
-      tags: {},
-    }
+  // 合并 transformAssetUrls
+  const transformAssetUrls = createUniVueTransformAssetUrls(
+    isExternalUrl(options.base) ? options.base : ''
+  );
+  const optionsTransformAssetUrls = templateOptions.transformAssetUrls;
+  templateOptions.transformAssetUrls = {
+    ...transformAssetUrls,
+    ...optionsTransformAssetUrls,
+    tags: {
+      ...transformAssetUrls.tags,
+      ...optionsTransformAssetUrls.tags,
+    },
+  }
+  if (options.platform !== 'h5' && options.platform !== 'web') {
     compilerOptions.nodeTransforms.push(...getBaseNodeTransforms(options.base))
   }
 

--- a/packages/vite-plugin-uni/src/vue/options.ts
+++ b/packages/vite-plugin-uni/src/vue/options.ts
@@ -1,6 +1,7 @@
 import fsExtra from 'fs-extra'
 import { hasOwn, isArray, isPlainObject } from '@vue/shared'
 import type {
+  AssetURLOptions,
   SFCStyleCompileOptions,
   TemplateCompiler,
 } from '@vue/compiler-sfc'
@@ -129,17 +130,30 @@ export function initPluginVueOptions(
     compilerOptions.nodeTransforms = []
   }
   // 合并 transformAssetUrls
-  const transformAssetUrls = createUniVueTransformAssetUrls(
-    isExternalUrl(options.base) ? options.base : ''
-  );
-  const optionsTransformAssetUrls = templateOptions.transformAssetUrls;
-  templateOptions.transformAssetUrls = {
-    ...transformAssetUrls,
-    ...optionsTransformAssetUrls,
-    tags: {
-      ...transformAssetUrls.tags,
-      ...optionsTransformAssetUrls.tags,
-    },
+
+  // 内置配置
+  const builtInTransformAssetUrls: AssetURLOptions =
+    createUniVueTransformAssetUrls(
+      isExternalUrl(options.base) ? options.base : ''
+    )
+  templateOptions.transformAssetUrls = builtInTransformAssetUrls
+
+  // 用户传递配置 eg: transformAssetUrls.tags = {'my-image': ['src']}
+  // docs: https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue
+  const userOptionsTransformAssetUrls = templateOptions.transformAssetUrls
+  if (
+    typeof userOptionsTransformAssetUrls !== 'boolean' &&
+    !!userOptionsTransformAssetUrls?.tags &&
+    !Array.isArray(userOptionsTransformAssetUrls.tags)
+  ) {
+    templateOptions.transformAssetUrls = {
+      ...builtInTransformAssetUrls,
+      ...userOptionsTransformAssetUrls,
+      tags: {
+        ...builtInTransformAssetUrls.tags,
+        ...userOptionsTransformAssetUrls.tags,
+      },
+    }
   }
   if (options.platform !== 'h5' && options.platform !== 'web') {
     compilerOptions.nodeTransforms.push(...getBaseNodeTransforms(options.base))


### PR DESCRIPTION
目前不支持用户传递  templateOptions.transformAssetUrls.tags 导致

``` html
<template>
  <div>
    <image :src="src"  mode="scaleToFill" />
  </div>
</template>
<script lang="ts" setup>

defineProps<{
  src: string;
}>();
</script>
```

这种自定义组件无法传递 props.src 参数