### PR TITLE
feat(mp): 支持npm link&monorepo等不在root路径下的软链接引用

### DIFF
--- a/packages/uni-cli-shared/src/utils.ts
+++ b/packages/uni-cli-shared/src/utils.ts
@@ -107,10 +107,16 @@ export function normalizeMiniProgramFilename(
   filename: string,
   inputDir?: string
 ) {
-  if (!inputDir || !path.isAbsolute(filename)) {
-    return normalizeNodeModules(filename)
+  let relativeFilename = filename
+  if (inputDir && path.isAbsolute(filename)) {
+    relativeFilename = path.relative(inputDir, filename)
   }
-  return normalizeNodeModules(path.relative(inputDir, filename))
+  if (/^\.\.(\/|\\)/.test(relativeFilename)) {
+    const level = `_${relativeFilename.match(/\.\.(\/|\\)/g)!.length}`
+    relativeFilename = relativeFilename.replace(/\.\.(\/|\\)/g, '')
+    relativeFilename = path.join('_symlinks', level, relativeFilename)
+  }
+  return normalizeNodeModules(relativeFilename)
 }
 
 export function normalizeParsePlugins(


### PR DESCRIPTION
将npm link/mpnorepo等软链接的引入路径的产物路径格式化到当前根目录下

原有实现：直接设置resolve.preserveSymlinks = true，在monorepo下，嵌套的对同一个包的引用会导致重复打包多次
vite在resolverId时解析的package.json路径是软连接的，嵌套的node_modules下的引用导致对同一个包的引用resolve出不同的id [vite:resolve packages](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/packages.ts#L96)

normalizeMiniProgramFilename这里如果支持引用不在根路径下的外部依赖，至少提供了用户可以不开启preserveSymlinks 的选择

相关问题：[关于monorepo开发项目，相同package被重复编译至vendor.js](https://ask.dcloud.net.cn/question/157763)

