### PR TITLE
fix: 微信小程序自定义组件click事件编译时补充tap事件

### DIFF
--- a/packages/uni-cli-shared/src/mp/template.ts
+++ b/packages/uni-cli-shared/src/mp/template.ts
@@ -42,7 +42,7 @@ export interface MiniProgramCompilerOptions {
     format?(
       name: string,
       opts: { isCatch?: boolean; isCapture?: boolean; isComponent?: boolean }
-    ): string
+    ): string | string[]
   }
   class: {
     /**

--- a/packages/uni-mp-compiler/src/template/codegen.ts
+++ b/packages/uni-mp-compiler/src/template/codegen.ts
@@ -490,16 +490,22 @@ function genOn(
   const arg = (prop.arg as SimpleExpressionNode).content
   const exp = prop.exp as SimpleExpressionNode
   const modifiers = prop.modifiers
-  const name = (event?.format || formatMiniProgramEvent)(arg, {
+  let names = (event?.format || formatMiniProgramEvent)(arg, {
     isCatch: modifiers.includes('stop') || modifiers.includes('prevent'),
     isCapture: modifiers.includes('capture'),
     isComponent: isUserComponent(node, { isBuiltInComponent }),
   })
-  if (exp.isStatic) {
-    push(` ${name}="${exp.content}"`)
-  } else {
-    push(` ${name}="{{${exp.content}}}"`)
+
+  if (!(names instanceof Array)) {
+    names = [names]
   }
+  names.forEach((name) => {
+    if (exp.isStatic) {
+      push(` ${name}="${exp.content}"`)
+    } else {
+      push(` ${name}="{{${exp.content}}}"`)
+    }
+  })
 }
 
 function genDirectiveNode(

--- a/packages/uni-mp-weixin/__tests__/vOn.spec.ts
+++ b/packages/uni-mp-weixin/__tests__/vOn.spec.ts
@@ -11,7 +11,7 @@ describe('mp-weixin: transform v-on', () => {
     )
     assert(
       `<custom v-on:click="onClick"/>`,
-      `<custom bindclick="{{a}}" u-i="2a9ec0b0-0" bind:__l="__l"/>`,
+      `<custom bindclick="{{a}}" bindtap="{{a}}" u-i="2a9ec0b0-0" bind:__l="__l"/>`,
       `(_ctx, _cache) => {
   return { a: _o(_ctx.onClick) }
 }`

--- a/packages/uni-mp-weixin/dist/uni.compiler.js
+++ b/packages/uni-mp-weixin/dist/uni.compiler.js
@@ -168,6 +168,16 @@ const miniProgram = {
     },
     event: {
         key: true,
+        format: function (eventName, { isCatch, isCapture, isComponent }) {
+            const events = [
+                uniCliShared.formatMiniProgramEvent(eventName, { isCatch, isCapture, isComponent })
+            ];
+            // 自定义组件上面的click事件，在微信小程序中需要额外绑定 bindtab事件
+            if (eventName === 'click' && isComponent) {
+                events.push(uniCliShared.formatMiniProgramEvent('tap', { isCatch, isCapture, isComponent: false }));
+            }
+            return events;
+        }
     },
     directive: 'wx:',
     lazyElement: {

--- a/packages/uni-mp-weixin/src/compiler/options.ts
+++ b/packages/uni-mp-weixin/src/compiler/options.ts
@@ -5,6 +5,7 @@ import {
   type MiniProgramCompilerOptions,
   copyMiniProgramPluginJson,
   copyMiniProgramThemeJson,
+  formatMiniProgramEvent,
   transformComponentLink,
   transformRef,
 } from '@dcloudio/uni-cli-shared'
@@ -68,6 +69,22 @@ export const miniProgram: MiniProgramCompilerOptions = {
   },
   event: {
     key: true,
+    format: function (eventName, { isCatch, isCapture, isComponent }) {
+      const events = [
+        formatMiniProgramEvent(eventName, { isCatch, isCapture, isComponent }),
+      ]
+      // 自定义组件上面的click事件，在微信小程序中需要额外绑定 bindtab事件
+      if (eventName === 'click' && isComponent) {
+        events.push(
+          formatMiniProgramEvent('tap', {
+            isCatch,
+            isCapture,
+            isComponent: false,
+          })
+        )
+      }
+      return events
+    },
   },
   directive: 'wx:',
   lazyElement: {


### PR DESCRIPTION
fix: 微信小程序自定义组件click事件编译时补充tap事件 [ask 197117](https://ask.dcloud.net.cn/question/197117), issue https://github.com/dcloudio/uni-app/issues/4877