### PR TITLE
fix(mp): 支持快手的动态插槽名

### DIFF
--- a/packages/uni-mp-kuaishou/src/compiler/options.ts
+++ b/packages/uni-mp-kuaishou/src/compiler/options.ts
@@ -36,7 +36,7 @@ export const miniProgram: MiniProgramCompilerOptions = {
   },
   slot: {
     fallbackContent: false,
-    dynamicSlotNames: false,
+    dynamicSlotNames: true,
   },
   directive: 'ks:',
   lazyElement: {


### PR DESCRIPTION
[#5280 ](https://github.com/dcloudio/uni-app/issues/5280) 快手小程序已经支持动态插槽名了，所以可以把编译选项打开。