### PR TITLE
fix(mp): 支持快手的插件事件

### DIFF
--- a/packages/uni-mp-kuaishou/src/compiler/options.ts
+++ b/packages/uni-mp-kuaishou/src/compiler/options.ts
@@ -23,6 +23,7 @@ export const customElements = [
   'follow-service',
   'payment-list',
   'web-view',
+  'playlet-plugin',
 ]
 
 export const compilerOptions: CompilerOptions = {


### PR DESCRIPTION
起因是使用快手小程序插件开发短剧功能 （[插件文档](https://open.kuaishou.com/docs/develop/functionAccessGuide/playletplugin.html)）,发现bindplay和bindpause相关事件无法触发，我看源码中（[文件](https://github.com/dcloudio/uni-app/blob/next/packages/uni-mp-kuaishou/src/compiler/transforms/vOn.ts)）说快手小程序的自定义组件，不支持动态事件绑定。所以建议先把playlet-plugin声明为内部组件来处理。

其次，快手1.99.3开始支持动态事件了，建议官方大佬可以重新调整一下这部分的逻辑了，感谢🙏。