### PR TITLE
fix Uncaught TypeError: e.querySelector is not a function at uni-app-view.umd.js

### DIFF
--- a/packages/uni-api/src/helpers/requestComponentObserver.ts
+++ b/packages/uni-api/src/helpers/requestComponentObserver.ts
@@ -73,7 +73,7 @@ export function requestComponentObserver(
     }
   } else {
     ;(intersectionObserver as any).USE_MUTATION_OBSERVER = false
-    const el = $el.querySelector(options.selector!)
+    const el = $el?.querySelector(options.selector!)
     if (!el) {
       console.warn(
         `Node ${options.selector} is not found. Intersection observer will not trigger.`

--- a/packages/uni-api/src/helpers/requestComponentObserver.ts
+++ b/packages/uni-api/src/helpers/requestComponentObserver.ts
@@ -73,7 +73,7 @@ export function requestComponentObserver(
     }
   } else {
     ;(intersectionObserver as any).USE_MUTATION_OBSERVER = false
-    const el = $el?.querySelector(options.selector!)
+    const el = $el?.querySelector && $el.querySelector(options.selector!)
     if (!el) {
       console.warn(
         `Node ${options.selector} is not found. Intersection observer will not trigger.`


### PR DESCRIPTION
启动时报错
[出现错误 e.querySelector is not a function at uni-app-view.umd.js](https://github.com/dcloudio/uni-app/issues/5201)
Uncaught TypeError: e.querySelector is not a function at uni-app-view.umd.js:17689