### PR TITLE
fix(app): inputmode为none时，设置focus为true能弹起键盘的bug (question/207894)

### DIFF
--- a/packages/uni-components/src/helpers/useField.ts
+++ b/packages/uni-components/src/helpers/useField.ts
@@ -369,7 +369,7 @@ function useAutoFocus(props: Props, fieldRef: Ref<HTMLFieldElement | null>) {
       } else {
         field.focus()
         // 无用户交互的 webview 需主动显示键盘（安卓）
-        if (!userActionState.userAction) {
+        if (!userActionState.userAction && props.inputmode !== 'none') {
           plus.key.showSoftKeybord()
         }
       }

--- a/packages/uni-components/src/helpers/useField.ts
+++ b/packages/uni-components/src/helpers/useField.ts
@@ -354,10 +354,12 @@ function useAutoFocus(props: Props, fieldRef: Ref<HTMLFieldElement | null>) {
         setTimeout(focus, timeout)
         return
       }
+      // inputmode为none，focus为true时，不允许自动弹出键盘
+      const isInputModeEnabled = props.inputmode !== 'none'
       // @ts-expect-error plus类型
       if (plus.os.name === 'HarmonyOS') {
         // 无用户交互的 webview 需主动显示键盘（鸿蒙）
-        if (!userActionState.userAction) {
+        if (!userActionState.userAction && isInputModeEnabled) {
           // 鸿蒙需要先显示键盘再focus，否则键盘类型、confirmType等设置无效
           plus.key.showSoftKeybord()
           setTimeout(() => {
@@ -369,7 +371,7 @@ function useAutoFocus(props: Props, fieldRef: Ref<HTMLFieldElement | null>) {
       } else {
         field.focus()
         // 无用户交互的 webview 需主动显示键盘（安卓）
-        if (!userActionState.userAction && props.inputmode !== 'none') {
+        if (!userActionState.userAction && isInputModeEnabled) {
           plus.key.showSoftKeybord()
         }
       }


### PR DESCRIPTION
# 相关帖子

[https://ask.dcloud.net.cn/question/207894](https://ask.dcloud.net.cn/question/207894)
[https://ask.dcloud.net.cn/question/183911](https://ask.dcloud.net.cn/question/183911)
[https://ask.dcloud.net.cn/question/163899](https://ask.dcloud.net.cn/question/163899)

# 效果

```vue
<template>  
  <view>  
    <view> val: {{ val }}  </view>
    <textarea inputmode="none" :focus="true" style="border: 1px solid red" />  
  </view>  
</template>  
<script lang="ts" setup>  
import { ref } from 'vue';  
const val = ref();  
</script>
```

## 修复前

https://github.com/user-attachments/assets/755c7e93-0177-4685-9f86-374e311046a5

## 修复后


https://github.com/user-attachments/assets/e876f914-8713-49b3-8166-e121ebfde8ed




