### PR TITLE
fix(app): inputmode为none时，设置focus为true弹起键盘的bug (question/207894)

### DIFF
--- a/src/core/view/mixins/field.js
+++ b/src/core/view/mixins/field.js
@@ -183,7 +183,7 @@ export default {
         }
         field.focus()
         // 无用户交互的 webview 需主动显示键盘（安卓）
-        if (!this.userInteract) {
+        if (!this.userInteract && this.inputmode !== 'none') {
           plus.key.showSoftKeybord()
         }
       }


### PR DESCRIPTION
# 测试代码

```vue
<template>
	<view class="content">
		<image class="logo" src="/static/logo.png"></image>
		<view class="text-area">
			<text class="title">{{title}}</text>
		</view>
		<textarea inputmode="none" :focus="true" style="border: 1px solid red" />
	</view>
</template>

<script>
	export default {
		data() {
			return {
				title: 'Hello'
			}
		},
		onLoad() {

		},
		methods: {

		}
	}
</script>
```

# 修复前


https://github.com/user-attachments/assets/adb00a75-4853-406e-9545-4dbd3eab7108

# 修复后


https://github.com/user-attachments/assets/9c8420e6-6912-4787-9126-75c88c813769

