### PR TITLE
fix(web): 修复uni.getSystemInfoSync().windowTop计算的值不正确 (question/139069)

### DIFF
--- a/packages/uni-h5/src/framework/setup/index.ts
+++ b/packages/uni-h5/src/framework/setup/index.ts
@@ -51,6 +51,7 @@ import {
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
 import { useRouter } from 'vue-router'
 import { handleBeforeEntryPageRoutes } from '../../service/api/route/utils'
+import { updateCurPageCssVar } from '../../helpers/cssVar'
 //#if _X_
 import { isDialogPageInstance } from '../../x/framework/helpers/utils'
 import {
@@ -142,6 +143,7 @@ export function setupPage(comp: any) {
         return query
       }
       const pageMeta = usePageMeta()
+      updateCurPageCssVar(pageMeta)
       // 动态监听子组件 onReachBottom, onPageScroll的hook，从而初始化pageScroll逻辑
       instance.onReachBottom = reactive([])
       instance.onPageScroll = reactive([])


### PR DESCRIPTION
# 关联帖子

[https://ask.dcloud.net.cn/question/139069](https://ask.dcloud.net.cn/question/139069)

# 复现代码

```vue
<template>
	<view class="content">
		<image class="logo" src="/static/logo.png"></image>
		<view class="text-area">
			<text class="title">{{title}}</text>
		</view>
	</view>
</template>

<script>
	export default {
		data() {
			return {
				title: ''
			}
		},
		onLoad() {
			const config = uni.getSystemInfoSync();
			this.title = `windowTop:${config.windowTop}`
		},
		methods: {

		}
	}
</script>
```

# 修复前

![before](https://github.com/user-attachments/assets/e19868fb-33f5-4003-89b0-970439379269)


# 修复后

![after](https://github.com/user-attachments/assets/50759f76-0cd2-40e1-b374-c28eddb00fde)
