### PR TITLE
fix(web): 修复showToast中title为英文短句时单词拆分的问题 (question/297992)

### DIFF
--- a/packages/uni-h5/style/api/toast.css
+++ b/packages/uni-h5/style/api/toast.css
@@ -31,7 +31,7 @@ uni-toast {
   font-size: 13px;
   text-align: center;
   max-width: 100%;
-  word-break: break-all;
+  word-break: break-word;
   white-space: normal;
 }
 


### PR DESCRIPTION
# 关联社区帖子

[https://ask.dcloud.net.cn/question/209029?item_id=297992&rf=false](https://ask.dcloud.net.cn/question/209029?item_id=297992&rf=false)

# 修复后效果

![image](https://github.com/user-attachments/assets/2e256880-f874-40e1-835a-909ca3d767ad)
