### PR TITLE
支持快手小程序动态事件

### DIFF
--- a/packages/uni-mp-kuaishou/__tests__/vModel.spec.ts
+++ b/packages/uni-mp-kuaishou/__tests__/vModel.spec.ts
@@ -4,18 +4,18 @@ describe('mp-kuaishou: transform v-model', () => {
   test(`component v-model`, () => {
     assert(
       `<Comp v-model="model" />`,
-      `<comp ks:if="{{b}}" u-i="2a9ec0b0-0" bind:__l="__l" eO="{{a}}" bindupdateModelValue="__e" u-p="{{b}}"/>`,
+      `<comp ks:if="{{b}}" u-i="2a9ec0b0-0" bind:__l="__l" bindupdateModelValue="{{a}}" u-p="{{b}}"/>`,
       `(_ctx, _cache) => {
-  return { a: _j({ 'updateModelValue': _o($event => _ctx.model = $event) }), b: _p({ modelValue: _ctx.model }) }
+  return { a: _o($event => _ctx.model = $event), b: _p({ modelValue: _ctx.model }) }
 }`
     )
   })
   test(`component v-model with cache`, () => {
     assert(
       `<Comp v-model="model" />`,
-      `<comp ks:if="{{b}}" u-i="2a9ec0b0-0" bind:__l="__l" eO="{{a}}" bindupdateModelValue="__e" u-p="{{b}}"/>`,
+      `<comp ks:if="{{b}}" u-i="2a9ec0b0-0" bind:__l="__l" bindupdateModelValue="{{a}}" u-p="{{b}}"/>`,
       `(_ctx, _cache) => {
-  return { a: _j({ 'updateModelValue': _o($event => _ctx.model = $event) }), b: _p({ modelValue: _ctx.model }) }
+  return { a: _o($event => _ctx.model = $event), b: _p({ modelValue: _ctx.model }) }
 }`,
       {
         cacheHandlers: true,
@@ -25,32 +25,32 @@ describe('mp-kuaishou: transform v-model', () => {
   test(`input,textarea v-model`, () => {
     assert(
       `<input v-model="model" />`,
-      `<input data-e-o="{{a}}" value="{{b}}" bindinput="__e"/>`,
+      `<input value="{{a}}" bindinput="{{b}}"/>`,
       `(_ctx, _cache) => {
-  return { a: { 'input': _o($event => _ctx.model = $event.detail.value) }, b: _ctx.model }
+  return { a: _ctx.model, b: _o($event => _ctx.model = $event.detail.value) }
 }`
     )
     assert(
       `<textarea v-model="model" />`,
-      `<textarea data-e-o="{{a}}" value="{{b}}" bindinput="__e"/>`,
+      `<textarea value="{{a}}" bindinput="{{b}}"/>`,
       `(_ctx, _cache) => {
-  return { a: { 'input': _o($event => _ctx.model = $event.detail.value) }, b: _ctx.model }
+  return { a: _ctx.model, b: _o($event => _ctx.model = $event.detail.value) }
 }`
     )
   })
   test(`input v-model + v-on`, () => {
     assert(
       `<input @input="input" v-model="model" />`,
-      `<input bindinput="__e" data-e-o="{{a}}" value="{{b}}"/>`,
+      `<input bindinput="{{a}}" value="{{b}}"/>`,
       `(_ctx, _cache) => {
-  return { a: { 'input': _o([$event => _ctx.model = $event.detail.value, _ctx.input]) }, b: _ctx.model }
+  return { a: _o([$event => _ctx.model = $event.detail.value, _ctx.input]), b: _ctx.model }
 }`
     )
     assert(
       `<input v-model="model" @input="input" />`,
-      `<input bindinput="__e" data-e-o="{{a}}" value="{{b}}"/>`,
+      `<input bindinput="{{a}}" value="{{b}}"/>`,
       `(_ctx, _cache) => {
-  return { a: { 'input': _o([$event => _ctx.model = $event.detail.value, _ctx.input]) }, b: _ctx.model }
+  return { a: _o([$event => _ctx.model = $event.detail.value, _ctx.input]), b: _ctx.model }
 }`
     )
   })

--- a/packages/uni-mp-kuaishou/__tests__/vOn.spec.ts
+++ b/packages/uni-mp-kuaishou/__tests__/vOn.spec.ts
@@ -5,18 +5,18 @@ describe('mp-kuaishou: transform v-on', () => {
     test(`input`, () => {
       assert(
         `<input @input="input"/>`,
-        `<input bindinput="__e" data-e-o="{{a}}"/>`,
+        `<input bindinput="{{a}}"/>`,
         `(_ctx, _cache) => {
-  return { a: { 'input': _o(_ctx.input) } }
+  return { a: _o(_ctx.input) }
 }`
       )
     })
     test(`textarea`, () => {
       assert(
         `<textarea @input="input"></textarea>`,
-        `<textarea bindinput="__e" data-e-o="{{a}}"></textarea>`,
+        `<textarea bindinput="{{a}}"></textarea>`,
         `(_ctx, _cache) => {
-  return { a: { 'input': _o(_ctx.input) } }
+  return { a: _o(_ctx.input) }
 }`
       )
     })
@@ -34,18 +34,18 @@ describe('mp-kuaishou: transform v-on', () => {
     test(`custom event`, () => {
       assert(
         `<custom @click="click"/>`,
-        `<custom bindclick="__e" u-i="2a9ec0b0-0" bind:__l="__l" eO="{{a}}"/>`,
+        `<custom bindclick="{{a}}" u-i="2a9ec0b0-0" bind:__l="__l"/>`,
         `(_ctx, _cache) => {
-  return { a: _j({ 'click': _o(_ctx.click) }) }
+  return { a: _o(_ctx.click) }
 }`
       )
     })
     test(`multi custom event`, () => {
       assert(
         `<custom @unmount="unmount" @custom-mount="mount();created();"/>`,
-        `<custom bindunmount="__e" bindcustomMount="__e" u-i="2a9ec0b0-0" bind:__l="__l" eO="{{a}}"/>`,
+        `<custom bindunmount="{{a}}" bindcustomMount="{{b}}" u-i="2a9ec0b0-0" bind:__l="__l"/>`,
         `(_ctx, _cache) => {
-  return { a: _j({ 'unmount': _o(_ctx.unmount), 'customMount': _o($event => { _ctx.mount(); _ctx.created(); }) }) }
+  return { a: _o(_ctx.unmount), b: _o($event => { _ctx.mount(); _ctx.created(); }) }
 }`
       )
     })
@@ -54,18 +54,18 @@ describe('mp-kuaishou: transform v-on', () => {
     test(`getphonenumber`, () => {
       assert(
         `<button open-type="getPhoneNumber" @getphonenumber="getInfo"></button>`,
-        `<button open-type="getPhoneNumber" bindgetphonenumber="__e" data-e-o="{{a}}"></button>`,
+        `<button open-type="getPhoneNumber" bindgetphonenumber="{{a}}"></button>`,
         `(_ctx, _cache) => {
-  return { a: { 'getphonenumber': _o(_ctx.getInfo) } }
+  return { a: _o(_ctx.getInfo) }
 }`
       )
     })
     test(`getuserextendinfo`, () => {
       assert(
         `<button open-type="getuserextendinfo" @getuserextendinfo="getInfo"></button>`,
-        `<button open-type="getuserextendinfo" bindgetuserextendinfo="__e" data-e-o="{{a}}"></button>`,
+        `<button open-type="getuserextendinfo" bindgetuserextendinfo="{{a}}"></button>`,
         `(_ctx, _cache) => {
-  return { a: { 'getuserextendinfo': _o(_ctx.getInfo) } }
+  return { a: _o(_ctx.getInfo) }
 }`
       )
     })

--- a/packages/uni-mp-kuaishou/src/compiler/options.ts
+++ b/packages/uni-mp-kuaishou/src/compiler/options.ts
@@ -8,14 +8,14 @@ import {
 import type { UniMiniProgramPluginOptions } from '@dcloudio/uni-mp-vite'
 
 import source from './project.config.json'
-import { transformOn } from './transforms/vOn'
-import { transformModel } from './transforms/vModel'
+// import { transformOn } from './transforms/vOn'
+// import { transformModel } from './transforms/vModel'
 
 const nodeTransforms = [transformRef, transformComponentLink]
-const directiveTransforms = {
-  on: transformOn,
-  model: transformModel,
-}
+// const directiveTransforms = {
+//   on: transformOn,
+//   model: transformModel,
+// }
 
 export const customElements = [
   'playlet',
@@ -27,7 +27,7 @@ export const customElements = [
 
 export const compilerOptions: CompilerOptions = {
   nodeTransforms,
-  directiveTransforms,
+  // directiveTransforms,
 }
 const COMPONENTS_DIR = 'kscomponents'
 export const miniProgram: MiniProgramCompilerOptions = {


### PR DESCRIPTION
#5332 支持快手小程序动态事件

快手小程序已经的微信对齐了组件事件相关功能，因此不需要对快手平台额外去处理组件事件。