### PR TITLE
 fix(components): 修复部分内置组件id属性无效的问题 (question/170515)

### DIFF
--- a/src/core/view/components/button/index.vue
+++ b/src/core/view/components/button/index.vue
@@ -124,7 +124,8 @@ export default {
         this._bindObjectListeners({
           class: [this.hovering ? this.hoverClass : ''],
           attrs: {
-            disabled: this.disabled
+            disabled: this.disabled,
+            id: this.id
           },
           on: {
             touchstart: this._hoverTouchStart,
@@ -145,7 +146,8 @@ export default {
         this._bindObjectListeners({
           class: [this.hovering ? this.hoverClass : ''],
           attrs: {
-            disabled: this.disabled
+            disabled: this.disabled,
+            id: this.id
           },
           on: {
             click: this._onClick

--- a/src/core/view/components/checkbox/index.vue
+++ b/src/core/view/components/checkbox/index.vue
@@ -1,5 +1,6 @@
 <template>
   <uni-checkbox
+    :id="id"
     :disabled="disabled"
     v-on="$listeners"
     @click="_onClick"

--- a/src/core/view/components/radio/index.vue
+++ b/src/core/view/components/radio/index.vue
@@ -1,5 +1,6 @@
 <template>
   <uni-radio
+    :id="id"
     :disabled="disabled"
     v-on="$listeners"
     @click="_onClick"

--- a/src/core/view/components/switch/index.vue
+++ b/src/core/view/components/switch/index.vue
@@ -1,5 +1,6 @@
 <template>
   <uni-switch
+    :id="id"
     :disabled="disabled"
     v-on="$listeners"
     @click="_onClick"


### PR DESCRIPTION
# 复现代码

```vue
<template>
	<view>
		<button id="button">DIY可视化</button>
		<switch id="switch" color="#FFCC33" style="transform:scale(0.7)" />
		<radio id="radio" value="r2" />未选中
		<checkbox id="checkbox" value="cb" checked="true" />选中
	</view>
</template>
<script>
	export default {
		mounted() {
			const view = uni.createSelectorQuery().in(this).select('#button')
			view
				.boundingClientRect((data) => {
					console.log("button 得到布局位置信息", data);
				})
				.exec();

			const view1 = uni.createSelectorQuery().in(this).select('#switch')
			view1
				.boundingClientRect((data) => {
					console.log("switch 得到布局位置信息", data);
				})
				.exec();

			const view2 = uni.createSelectorQuery().in(this).select('#radio')
			view2
				.boundingClientRect((data) => {
					console.log("radio 得到布局位置信息", data);
				})
				.exec();

			const view3 = uni.createSelectorQuery().in(this).select('#checkbox')
			view3
				.boundingClientRect((data) => {
					console.log("checkbox 得到布局位置信息", data);
				})
				.exec();
		},
	}
</script>
```

# 修复前效果

![image](https://github.com/user-attachments/assets/8cf44266-8dd6-456e-8704-e5926cfcee50)


# 修复后效果

![image](https://github.com/user-attachments/assets/fed7aa3e-41c4-48b2-882e-0b683cf90ae0)
