### PR TITLE
fix(web): 修复关闭图片预览后未移除挂载的DOM元素的bug (question/298684)

### DIFF
--- a/packages/uni-h5/src/service/api/media/previewImage/index.ts
+++ b/packages/uni-h5/src/service/api/media/previewImage/index.ts
@@ -20,6 +20,8 @@ const closePreviewImageView = () => {
   nextTick(() => {
     imagePreviewInstance?.unmount()
     imagePreviewInstance = null
+    const rootEl = document.getElementById('u-a-p')
+    rootEl && document.body.removeChild(rootEl)
   })
 }
 


### PR DESCRIPTION
# 关联帖子

[https://ask.dcloud.net.cn/question/209528?item_id=298684&rf=false](https://ask.dcloud.net.cn/question/209528?item_id=298684&rf=false)