### PR TITLE
fix(mp): 修复小程序端 &lt; 和 &gt; 编译为 < 和 > 导致运行报错的bug (question/60628)

### DIFF
--- a/packages/uni-mp-compiler/src/template/codegen.ts
+++ b/packages/uni-mp-compiler/src/template/codegen.ts
@@ -157,7 +157,16 @@ function genText(node: TextNode, { push, isX }: TemplateCodegenContext) {
   if (isX) {
     push(mpEscapeText(node.content))
   } else {
-    push(node.content)
+    // 目前暂时只处理 < 和 >
+    push(
+      getEscaper(
+        /[<>\u2009\u00A0\u2002\u2003]/g,
+        new Map([
+          [60, '&lt;'],
+          [62, '&gt;'],
+        ])
+      )(node.content)
+    )
   }
 }
 


### PR DESCRIPTION
# 社区帖子

[https://ask.dcloud.net.cn/question/60628](https://ask.dcloud.net.cn/question/60628)

# 测试效果

![mp1](https://github.com/user-attachments/assets/fac7cdae-00fd-496d-87d0-1d251593a508)
![mp2](https://github.com/user-attachments/assets/d3f95196-8b82-4f01-8b77-f6450eb70751)
