### PR TITLE
fix(mp): 修复小程序 hidden 属性通过 v-bind 绑定变量失效的bug (question/204902)

### DIFF
--- a/packages/uni-mp-compiler/__tests__/hidden.spec.ts
+++ b/packages/uni-mp-compiler/__tests__/hidden.spec.ts
@@ -1,0 +1,41 @@
+import { assert } from './testUtils'
+
+describe('compiler: transform hidden', () => {
+  test('v-bind:hidden basic', () => {
+    assert(
+      `<view :hidden="true"/>`,
+      `<view hidden="{{true}}"/>`,
+      `(_ctx, _cache) => {
+  return {}
+}`
+    )
+    assert(
+      `<view :hidden="false"/>`,
+      `<view hidden="{{false}}"/>`,
+      `(_ctx, _cache) => {
+  return {}
+}`
+    )
+    assert(
+      `<view hidden />`,
+      `<view hidden/>`,
+      `(_ctx, _cache) => {
+  return {}
+}`
+    )
+    assert(
+      `<view :hidden="foo"/>`,
+      `<view hidden="{{a}}"/>`,
+      `(_ctx, _cache) => {
+  return { a: _ctx.foo }
+}`
+    )
+    assert(
+      `<view :hidden="foo | bar"/>`,
+      `<view hidden="{{a}}"/>`,
+      `(_ctx, _cache) => {
+  return { a: _ctx.foo | _ctx.bar }
+}`
+    )
+  })
+})

--- a/packages/uni-mp-compiler/src/transforms/transformHidden.ts
+++ b/packages/uni-mp-compiler/src/transforms/transformHidden.ts
@@ -86,6 +86,10 @@ export function rewriteHidden(
     } else {
       hiddenBindingExpr = virtualHostHiddenPolyfill
     }
+  } else if (expr) {
+    hiddenBindingExpr = identifier(
+      rewriteExpression(bindingProp.exp!, context).content
+    )
   } else {
     // ignore rewrite without virtualHost
     return


### PR DESCRIPTION
# 社区帖子

[https://ask.dcloud.net.cn/question/204902](https://ask.dcloud.net.cn/question/204902)

# 问题复现

![image](https://github.com/user-attachments/assets/c8a5813c-9a77-4bad-8093-0d662ecae50c)

