### PR TITLE
fix(textarea): 修复全输入符号设置 auto-height 属性不会自动增加高度的bug (question/173645)

### DIFF
--- a/packages/uni-components/src/vue/textarea/index.tsx
+++ b/packages/uni-components/src/vue/textarea/index.tsx
@@ -231,7 +231,12 @@ export default /*#__PURE__*/ defineBuiltInComponent({
             <div ref={lineRef} class="uni-textarea-line">
               {' '}
             </div>
-            <div class="uni-textarea-compute">
+            <div
+              class={{
+                'uni-textarea-compute': true,
+                'uni-textarea-compute-auto-height': props.autoHeight,
+              }}
+            >
               {valueCompute.value.map((item) => (
                 <div>{item.trim() ? item : '.'}</div>
               ))}

--- a/packages/uni-components/style/textarea.css
+++ b/packages/uni-components/style/textarea.css
@@ -54,6 +54,10 @@ uni-textarea[hidden] {
 .uni-textarea-line {
   width: 1em;
 }
+.uni-textarea-compute-auto-height {
+  /* 解决全输入符号设置auto-height不会自动增加高度 */
+  overflow-wrap: break-word;
+}
 .uni-textarea-textarea {
   resize: none;
   background: none;


### PR DESCRIPTION
# 社区帖子

[https://ask.dcloud.net.cn/question/173645](https://ask.dcloud.net.cn/question/173645)

# 影响范围

1.0 的 app和web端，2.0 的 web 端

# 复现代码

```vue
<template>
    <textarea
      placeholder="请输入"
      auto-height
      style="width: 100px; border: 1px solid red"
    />
</template>
```

# 问题复现

![20250525122907_rec_](https://github.com/user-attachments/assets/eb915604-1ab4-49e4-a91b-3f29bd9979af)


# 修复效果

![20250525123021_rec_](https://github.com/user-attachments/assets/67d99b35-5c92-489f-85d2-30def144a57f)
