### PR TITLE
fix(x-web): 修复match-media组件不生效的bug

### DIFF
--- a/packages/uni-components/lib-x/uni-match-media/uni-match-media.vue
+++ b/packages/uni-components/lib-x/uni-match-media/uni-match-media.vue
@@ -1,0 +1,78 @@
+<template>
+    <view v-show="matches">
+      <slot />
+    </view>
+  </template>
+  
+  <script>
+  let mediaQueryObserver
+  export default {
+    name: 'UniMatchMedia',
+    props: {
+      width: {
+        type: [Number, String],
+        default: ''
+      },
+      minWidth: {
+        type: [Number, String],
+        default: ''
+      },
+      maxWidth: {
+        type: [Number, String],
+        default: ''
+      },
+      height: {
+        type: [Number, String],
+        default: ''
+      },
+      minHeight: {
+        type: [Number, String],
+        default: ''
+      },
+      maxHeight: {
+        type: [Number, String],
+        default: ''
+      },
+      orientation: {
+        type: String,
+        default: ''
+      }
+    },
+  
+    data () {
+      return {
+        matches: true
+      }
+    },
+  
+    mounted () {
+      let parent = this.$parent
+      while (parent.$parent) {
+          parent = parent.$parent
+      }
+      mediaQueryObserver = uni.createMediaQueryObserver(parent)
+      mediaQueryObserver.observe({
+        width: this.width,
+        maxWidth: this.maxWidth,
+        minWidth: this.minWidth,
+        height: this.height,
+        minHeight: this.minHeight,
+        maxHeight: this.maxHeight,
+        orientation: this.orientation
+      }, matches => {
+        this.matches = matches
+      })
+    },
+  
+    destroyed () {
+      mediaQueryObserver.disconnect()
+    }
+  }
+  </script>
+  
+  <style>
+      view {
+          display: block;
+      }
+  </style>
+  


### PR DESCRIPTION
# 测试代码

```vue
<template>
	<match-media min-width="300" max-width="600">
		<view>当页面宽度在 300 ~ 600 px 之间时展示这里</view>
	</match-media>

	<match-media min-height="400" orientation="landscape">
		<view>当页面高度不小于 400 px 且屏幕方向为纵向时展示这里</view>
	</match-media>
</template>
```

# 问题截图

![image](https://github.com/user-attachments/assets/469af96c-082e-46e9-80cb-59aec22792bb)

# 修复效果

https://github.com/user-attachments/assets/27ba3430-70ae-47d2-9039-2be4b040e39e
