### PR TITLE
fix: 修复 slider 组件无法通过 id 查询节点信息的bug (question/209773)

### DIFF
--- a/src/core/view/components/slider/index.vue
+++ b/src/core/view/components/slider/index.vue
@@ -1,5 +1,6 @@
 <template>
   <uni-slider
+    :id="id"
     ref="uni-slider"
     v-on="$listeners"
     @click="_onClick"
@@ -117,6 +118,10 @@ export default {
   mixins: [emitter, listeners, touchtrack],
   props: {
     name: {
+      type: String,
+      default: ''
+    },
+    id: {
       type: String,
       default: ''
     },


### PR DESCRIPTION
# 社区帖子

[https://ask.dcloud.net.cn/question/209773](https://ask.dcloud.net.cn/question/209773)

# 问题复现

## APP

![image](https://github.com/user-attachments/assets/02ea5ecf-d5aa-4797-8fc9-9a3fd9c54414)

![image](https://github.com/user-attachments/assets/d51f6cc1-7b25-4405-bee1-ca01d51f7521)


## Web

![image](https://github.com/user-attachments/assets/7642a627-39a7-4700-8c2f-39705cf2dfc5)

# 修复效果

## APP

![image](https://github.com/user-attachments/assets/d0ef6cce-04a2-4007-bf48-b0c93e64cc8d)

![image](https://github.com/user-attachments/assets/2826d198-98ae-4fce-92c4-d2b532d21f23)


## Web

![image](https://github.com/user-attachments/assets/bc61a9ac-7193-4271-8f0c-64ca65e3b3e0)


