### PR TITLE
fix(mp-alipay): 修复 vue2 中 manifest.json设置axmlStrictCheck、enableParallelLoader…

### DIFF
--- a/packages/webpack-uni-pages-loader/lib/platforms/mp-alipay.js
+++ b/packages/webpack-uni-pages-loader/lib/platforms/mp-alipay.js
@@ -79,7 +79,7 @@ function parseCondition (pagesJson) {
   }
 }
 
-const projectKeys = ['component2', 'enableAppxNg']
+const projectKeys = ['component2', 'enableAppxNg', 'axmlStrictCheck', 'enableParallelLoader', 'enableDistFileMinify']
 
 module.exports = function (pagesJson, manifestJson) {
   const app = {
@@ -134,6 +134,9 @@ module.exports = function (pagesJson, manifestJson) {
   } else {
     project.component2 = hasOwn(platformJson, 'component2') ? platformJson.component2 : true
     project.enableAppxNg = hasOwn(platformJson, 'enableAppxNg') ? platformJson.enableAppxNg : true
+    project.axmlStrictCheck = hasOwn(platformJson, 'axmlStrictCheck') ? platformJson.axmlStrictCheck : false
+    project.enableParallelLoader = hasOwn(platformJson, 'enableParallelLoader') ? platformJson.enableParallelLoader : false
+    project.enableDistFileMinify = hasOwn(platformJson, 'enableDistFileMinify') ? platformJson.enableDistFileMinify : false
   }
 
   parseCondition(pagesJson)


### PR DESCRIPTION
…和enableDistFileMinify无效的bug

# 问题

文档中支持 axmlStrictCheck、enableParallelLoader和enableDistFileMinify。

但是编译之后，这三个属性却在 `app.json` 中，[支付宝小程序官方文档](https://opendocs.alipay.com/mini/framework/project) 写的是这三个属性是在 `mini.project.json` 中

![image](https://github.com/user-attachments/assets/64505c10-c99a-40d0-b52e-fc504259a6b3)

![image](https://github.com/user-attachments/assets/b3dbb9aa-3527-4687-b0de-3ad79b324f24)

![image](https://github.com/user-attachments/assets/d343d4cd-6e8e-4300-82ba-179f09cdd71e)

# 修复后效果

![image](https://github.com/user-attachments/assets/6c0e5948-48ee-4ebd-ab7b-d9ccabc34938)

