### PR TITLE
【BUGFIX】修复嵌套列表更新列表后组件实例复用导致动态属性丢失问题

### DIFF
--- a/packages/uni-mp-core/src/runtime/componentOptions.ts
+++ b/packages/uni-mp-core/src/runtime/componentOptions.ts
@@ -78,6 +78,9 @@ export function updateComponentProps(
     if (hasQueueJob(instance.update)) {
       invalidateJob(instance.update)
     }
+    // 修复列表组件复用时导致的组件动态属性丢失问题
+    // 最小复现demo https://developers.weixin.qq.com/s/ZvNerFmK8y0f
+    instance.effect.dirty = true
     if (
       __PLATFORM__ === 'mp-toutiao' ||
       __PLATFORM__ === 'mp-baidu' ||


### PR DESCRIPTION
￼￼最小复现代码如下图所示

[小程序代码片段](https://developers.weixin.qq.com/s/ZvNerFmK8y0f)
![Pasted Graphic](https://github.com/user-attachments/assets/efbdd936-0baf-4c72-9d4f-aeb3427d2f9b)
![Pasted Graphic 1](https://github.com/user-attachments/assets/554877af-ce6b-4d32-9fed-f968f8fd0ebc)


经过排查发现uni内置的vue框架中丢失如下代码

```typescript
function updateComponentProps(up, instance) {
  const prevProps = toRaw(instance.props);
  const nextProps = findComponentPropsData(up) || {};
  if (hasPropsChanged(prevProps, nextProps)) {
    updateProps(instance, nextProps, prevProps);
    if (hasQueueJob(instance.update)) {
      invalidateJob(instance.update);
    }
    {
      // 下面这行的作用就是告诉effect去执行render更新，但是uni框架删除了这行代码，不知道什么原因
      instance.effect.dirty = true
      instance.update();
    }
  }
}

```