### PR TITLE
feat(mp-toutiao): 支持拷贝 project.private.config.json 到产物根目录

### DIFF
--- a/packages/uni-mp-toutiao/src/compiler/options.ts
+++ b/packages/uni-mp-toutiao/src/compiler/options.ts
@@ -80,7 +80,7 @@ export const options: UniMiniProgramPluginOptions = {
       assets: [COMPONENTS_DIR],
       targets: [
         {
-          src: ['ext.json', 'package.json'],
+          src: ['ext.json', 'package.json', 'project.private.config.json'],
           get dest() {
             return process.env.UNI_OUTPUT_DIR
           },


### PR DESCRIPTION
# 文档

![image](https://github.com/user-attachments/assets/9b555cfb-1af6-4d05-9555-45c6c39a8b29)

[https://developer.open-douyin.com/docs/resource/zh-CN/mini-app/develop/dev-tools/developer-instrument/development-assistance/private-config](https://developer.open-douyin.com/docs/resource/zh-CN/mini-app/develop/dev-tools/developer-instrument/development-assistance/private-config)