### PR TITLE
fix(mp): 修复子组件 slot 有 props 导致父组件默认插槽不生效的bug (question/199966)

### DIFF
--- a/packages/uni-mp-compiler/__tests__/scopedSlot.spec.ts
+++ b/packages/uni-mp-compiler/__tests__/scopedSlot.spec.ts
@@ -4,14 +4,14 @@ describe('compiler: transform scoped slots', () => {
   test('basic', () => {
     assert(
       `<view><slot data="123"/></view>`,
-      `<view><slot name="d"/></view>`,
+      `<view><slot name="d"/><slot/></view>`,
       `(_ctx, _cache) => {
   return { a: _r("d", { data: "123" }) }
 }`
     )
     assert(
       `<view><slot :item="item" :index="index"/></view>`,
-      `<view><slot name="d"/></view>`,
+      `<view><slot name="d"/><slot/></view>`,
       `(_ctx, _cache) => {
   return { a: _r("d", { item: _ctx.item, index: _ctx.index }) }
 }`

--- a/packages/uni-mp-compiler/src/transforms/transformSlot.ts
+++ b/packages/uni-mp-compiler/src/transforms/transformSlot.ts
@@ -13,7 +13,7 @@ import {
   isStaticArgOf,
   isStaticExp,
 } from '@vue/compiler-core'
-import { camelize } from '@vue/shared'
+import { camelize, extend } from '@vue/shared'
 import { SLOT_DEFAULT_NAME, dynamicSlotName } from '@dcloudio/uni-shared'
 import { RENDER_SLOT } from '../runtimeHelpers'
 import { genExpr } from '../codegen'
@@ -120,6 +120,26 @@ export function rewriteSlot(node: SlotOutletNode, context: TransformContext) {
         ]),
         context
       )
+
+      const isEmptyDefaultSlot =
+        node.props.some(
+          (p) =>
+            p.type === NodeTypes.ATTRIBUTE &&
+            p.name === 'name' &&
+            p.value?.content === SLOT_DEFAULT_NAME
+        ) && node.children.length === 0
+      // 当存在 <slot name="default" :xxx="xxx"/> 时，在后面添加 <slot></slot>，使默认插槽生效
+      if (isEmptyDefaultSlot && Array.isArray(context.parent?.children)) {
+        context.parent.children.splice(
+          context.childIndex + 1,
+          0,
+          extend({}, node, {
+            props: [],
+            children: [],
+            loc: {},
+          })
+        )
+      }
     } else {
       // 非作用域默认插槽直接移除命名
       if (slotName === `"${SLOT_DEFAULT_NAME}"`) {


### PR DESCRIPTION
# 社区帖子

[https://ask.dcloud.net.cn/question/199966](https://ask.dcloud.net.cn/question/199966)

# 复现代码

```vue
// index.vue
<template>
  <view>
    <test>
      <template #default>#default</template>
    </test>
    <test>
      <template v-slot:default>v-slot:default</template>
    </test>
    <test>
      <template v-slot>v-slot</template>
    </test>
    <test>
      no any template
    </test>
  </view>
</template>
<script setup>
import test from "./test.vue";
</script>
```

```vue
// test.vue
<template>
	<view>
		<slot :subTitle="subTitle"></slot>
	</view>
</template>
<script setup>
import { ref } from 'vue'
const subTitle =  ref('test');
</script>
```

# 测试效果

![image](https://github.com/user-attachments/assets/d6854a90-a6b6-489e-ab46-d559f5c97754)

# 修复效果

![image](https://github.com/user-attachments/assets/8e5bc7dc-ff25-482f-b5d6-47e9a62f053a)
