### PR TITLE
fix(mp): 修复子组件 slot 有默认内容和 props 时父组件默认插槽不生效的bug

### DIFF
--- a/packages/uni-mp-compiler/__tests__/scopedSlot.spec.ts
+++ b/packages/uni-mp-compiler/__tests__/scopedSlot.spec.ts
@@ -38,7 +38,7 @@ describe('compiler: transform scoped slots', () => {
   test('v-for + v-for + scoped slots', () => {
     assert(
       `<view v-for="(item, index) in 4" :key="index"><view v-for="(item, index) in 4"><slot :text="1"></slot></view></view>`,
-      `<view wx:for="{{a}}" wx:for-item="item" wx:key="b"><view wx:for="{{item.a}}" wx:for-item="item"><slot name="{{item.a}}"></slot></view></view>`,
+      `<view wx:for="{{a}}" wx:for-item="item" wx:key="b"><view wx:for="{{item.a}}" wx:for-item="item"><slot name="{{item.a}}"></slot><slot></slot></view></view>`,
       `(_ctx, _cache) => {
   return { a: _f(4, (item, index, i0) => { return { a: _f(4, (item, index, i1) => { return { a: "d-" + i0 + '-' + i1, b: _r("d", { text: 1 }, i0 + '-' + i1) }; }), b: index }; }) }
 }`
@@ -47,7 +47,7 @@ describe('compiler: transform scoped slots', () => {
   test('v-for + v-for + v-for + scoped slots', () => {
     assert(
       `<view v-for="(item, index) in 4" :key="index"><view v-for="(item, index) in 4"><view v-for="(item, index) in 4"><slot :text="1"></slot></view></view></view>`,
-      `<view wx:for="{{a}}" wx:for-item="item" wx:key="b"><view wx:for="{{item.a}}" wx:for-item="item"><view wx:for="{{item.a}}" wx:for-item="item"><slot name="{{item.a}}"></slot></view></view></view>`,
+      `<view wx:for="{{a}}" wx:for-item="item" wx:key="b"><view wx:for="{{item.a}}" wx:for-item="item"><view wx:for="{{item.a}}" wx:for-item="item"><slot name="{{item.a}}"></slot><slot></slot></view></view></view>`,
       `(_ctx, _cache) => {
   return { a: _f(4, (item, index, i0) => { return { a: _f(4, (item, index, i1) => { return { a: _f(4, (item, index, i2) => { return { a: "d-" + i0 + '-' + i1 + '-' + i2, b: _r("d", { text: 1 }, i0 + '-' + i1 + '-' + i2) }; }) }; }), b: index }; }) }
 }`

--- a/packages/uni-mp-compiler/__tests__/scopedSlot.spec.ts
+++ b/packages/uni-mp-compiler/__tests__/scopedSlot.spec.ts
@@ -4,14 +4,14 @@ describe('compiler: transform scoped slots', () => {
   test('basic', () => {
     assert(
       `<view><slot data="123"/></view>`,
-      `<view><slot name="d"/></view>`,
+      `<view><slot name="d"/><slot/></view>`,
       `(_ctx, _cache) => {
   return { a: _r("d", { data: "123" }) }
 }`
     )
     assert(
       `<view><slot :item="item" :index="index"/></view>`,
-      `<view><slot name="d"/></view>`,
+      `<view><slot name="d"/><slot/></view>`,
       `(_ctx, _cache) => {
   return { a: _r("d", { item: _ctx.item, index: _ctx.index }) }
 }`

--- a/packages/uni-mp-compiler/__tests__/slot.fallback.spec.ts
+++ b/packages/uni-mp-compiler/__tests__/slot.fallback.spec.ts
@@ -29,6 +29,16 @@ describe('compiler: transform slot', () => {
       options
     )
   })
+  test('default slot with fallback content and props', () => {
+    assert(
+      `<button><slot :title="title">fallback</slot></button>`,
+      `<button><block wx:if="{{$slots.d}}"><slot name="d"></slot><slot/></block><block wx:else><slot>fallback</slot></block></button>`,
+      `(_ctx, _cache) => {
+  return { a: _r("d", { title: _ctx.title }) }
+}`,
+      options
+    )
+  })
   test('names slots', () => {
     assert(
       `<button><slot name="text"/></button>`,

--- a/packages/uni-mp-compiler/__tests__/slot.spec.ts
+++ b/packages/uni-mp-compiler/__tests__/slot.spec.ts
@@ -142,7 +142,7 @@ describe('compiler: transform slot', () => {
   test('slot with v-for', () => {
     assert(
       `<slot v-for="(item,index) in items" :key="index"></slot>`,
-      `<slot wx:for="{{a}}" wx:for-item="item" name="{{item.a}}"></slot>`,
+      `<slot wx:for="{{a}}" wx:for-item="item" name="{{item.a}}"></slot><slot wx:for="{{a}}" wx:for-item="item"></slot>`,
       `(_ctx, _cache) => {
   return { a: _f(_ctx.items, (item, index, i0) => { return { a: "d-" + i0, b: _r("d", { key: index }, i0) }; }) }
 }`
@@ -158,7 +158,7 @@ describe('compiler: transform slot', () => {
   test('slot with v-for + v-for', () => {
     assert(
       `<view v-for="(item,index) in items" :key="index"><slot v-for="(item1,index1) in item.list" :key="index1"></slot></view>`,
-      `<view wx:for="{{a}}" wx:for-item="item" wx:key="b"><slot wx:for="{{item.a}}" wx:for-item="item1" name="{{item1.a}}"></slot></view>`,
+      `<view wx:for="{{a}}" wx:for-item="item" wx:key="b"><slot wx:for="{{item.a}}" wx:for-item="item1" name="{{item1.a}}"></slot><slot wx:for="{{item.a}}" wx:for-item="item1"></slot></view>`,
       `(_ctx, _cache) => {
   return { a: _f(_ctx.items, (item, index, i0) => { return { a: _f(item.list, (item1, index1, i1) => { return { a: "d-" + i0 + '-' + i1, b: _r("d", { key: index1 }, i0 + '-' + i1) }; }), b: index }; }) }
 }`

--- a/packages/uni-mp-compiler/__tests__/slot.spec.ts
+++ b/packages/uni-mp-compiler/__tests__/slot.spec.ts
@@ -56,6 +56,15 @@ describe('compiler: transform slot', () => {
 }`
     )
   })
+  test('fallback content with prop', () => {
+    assert(
+      `<button><slot :foo="foo">Submit</slot></button>`,
+      `<button><block wx:if="{{$slots.d}}"><slot name="d"></slot><slot/></block><block wx:else>Submit</block></button>`,
+      `(_ctx, _cache) => {
+  return { a: _r("d", { foo: _ctx.foo }) }
+}`
+    )
+  })
   test('names slots', () => {
     assert(
       `<button><slot name="text"/></button>`,

--- a/packages/uni-mp-compiler/src/template/codegen.ts
+++ b/packages/uni-mp-compiler/src/template/codegen.ts
@@ -249,6 +249,10 @@ function genSlot(node: SlotOutletNode, context: TemplateCodegenContext) {
   }
   push(`>`)
   genElement(node, context)
+  // 当存在 <slot name="default" :xxx="xxx">foo<slot> 时，在后面添加 <slot></slot>，使默认插槽生效
+  if (name === SLOT_DEFAULT_NAME && node.props.length) {
+    push(`<slot/>`)
+  }
   push(`</block>`)
   push(`<block`)
   genVElse(context)

--- a/packages/uni-mp-compiler/src/template/codegen.ts
+++ b/packages/uni-mp-compiler/src/template/codegen.ts
@@ -231,7 +231,16 @@ function genSlot(node: SlotOutletNode, context: TemplateCodegenContext) {
       return prop.arg.content === 'name'
     }
   })
-  if (!node.children.length || context.slot.fallbackContent) {
+  const isDefaultSlot = node.props.some(
+    (p) =>
+      p.type === NodeTypes.ATTRIBUTE &&
+      p.name === 'name' &&
+      p.value?.content === SLOT_DEFAULT_NAME
+  )
+  if (
+    !node.children.length ||
+    (context.slot.fallbackContent && !isDefaultSlot)
+  ) {
     // 无后备内容或支持后备内容
     return genElement(node, context)
   }
@@ -275,9 +284,16 @@ function genSlot(node: SlotOutletNode, context: TemplateCodegenContext) {
   push(`<block`)
   genVElse(context)
   push(`>`)
+  // 默认插槽 且支持 fallback，fallback 需要包裹在 <slot> 中
+  if (context.slot.fallbackContent && isDefaultSlot) {
+    push(`<slot>`)
+  }
   children.forEach((node) => {
     genNode(node, context)
   })
+  if (context.slot.fallbackContent && isDefaultSlot) {
+    push(`</slot>`)
+  }
   push(`</block>`)
   if (isVIfSlot) {
     push(`</block>`)

--- a/packages/uni-mp-compiler/src/template/codegen.ts
+++ b/packages/uni-mp-compiler/src/template/codegen.ts
@@ -277,7 +277,7 @@ function genSlot(node: SlotOutletNode, context: TemplateCodegenContext) {
   push(`>`)
   genElement(node, context)
   // 当存在 <slot name="default" :xxx="xxx"> fallback <slot> 时，在后面添加 <slot></slot>，使默认插槽生效
-  if (name === SLOT_DEFAULT_NAME && node.props.length) {
+  if (isDefaultSlot) {
     push(`<slot/>`)
   }
   push(`</block>`)

--- a/packages/uni-mp-compiler/src/transforms/transformSlot.ts
+++ b/packages/uni-mp-compiler/src/transforms/transformSlot.ts
@@ -13,7 +13,7 @@ import {
   isStaticArgOf,
   isStaticExp,
 } from '@vue/compiler-core'
-import { camelize, extend } from '@vue/shared'
+import { camelize } from '@vue/shared'
 import { SLOT_DEFAULT_NAME, dynamicSlotName } from '@dcloudio/uni-shared'
 import { RENDER_SLOT } from '../runtimeHelpers'
 import { genExpr } from '../codegen'
@@ -120,26 +120,6 @@ export function rewriteSlot(node: SlotOutletNode, context: TransformContext) {
         ]),
         context
       )
-
-      const isEmptyDefaultSlot =
-        node.props.some(
-          (p) =>
-            p.type === NodeTypes.ATTRIBUTE &&
-            p.name === 'name' &&
-            p.value?.content === SLOT_DEFAULT_NAME
-        ) && node.children.length === 0
-      // 当存在 <slot name="default" :xxx="xxx"/> 时，在后面添加 <slot></slot>，使默认插槽生效
-      if (isEmptyDefaultSlot && Array.isArray(context.parent?.children)) {
-        context.parent.children.splice(
-          context.childIndex + 1,
-          0,
-          extend({}, node, {
-            props: [],
-            children: [],
-            loc: {},
-          })
-        )
-      }
     } else {
       // 非作用域默认插槽直接移除命名
       if (slotName === `"${SLOT_DEFAULT_NAME}"`) {

--- a/packages/uni-mp-compiler/src/transforms/transformSlot.ts
+++ b/packages/uni-mp-compiler/src/transforms/transformSlot.ts
@@ -13,7 +13,7 @@ import {
   isStaticArgOf,
   isStaticExp,
 } from '@vue/compiler-core'
-import { camelize } from '@vue/shared'
+import { camelize, extend } from '@vue/shared'
 import { SLOT_DEFAULT_NAME, dynamicSlotName } from '@dcloudio/uni-shared'
 import { RENDER_SLOT } from '../runtimeHelpers'
 import { genExpr } from '../codegen'
@@ -120,6 +120,26 @@ export function rewriteSlot(node: SlotOutletNode, context: TransformContext) {
         ]),
         context
       )
+
+      const isEmptyDefaultSlot =
+        node.props.some(
+          (p) =>
+            p.type === NodeTypes.ATTRIBUTE &&
+            p.name === 'name' &&
+            p.value?.content === SLOT_DEFAULT_NAME
+        ) && node.children.length === 0
+      // 当存在 <slot name="default" :xxx="xxx"/> 时，在后面添加 <slot></slot>，使默认插槽生效
+      if (isEmptyDefaultSlot && Array.isArray(context.parent?.children)) {
+        context.parent.children.splice(
+          context.childIndex + 1,
+          0,
+          extend({}, node, {
+            props: [],
+            children: [],
+            loc: {},
+          })
+        )
+      }
     } else {
       // 非作用域默认插槽直接移除命名
       if (slotName === `"${SLOT_DEFAULT_NAME}"`) {


### PR DESCRIPTION
# 复现代码

```vue
// index.vue
<template>
  <view>
    <test> hello </test>
  </view>
</template>
<script setup>
import test from "./test.vue";
</script>
```

```vue
<template>
	<view>
		<slot :subTitle="subTitle">ddd</slot>
	</view>
</template>
<script setup>
import { ref } from 'vue'
const subTitle =  ref('test');
</script>
```

# 测试效果

![image](https://github.com/user-attachments/assets/ece28404-6b0e-4285-9d0f-28a1844be460)

# 修复效果

![image](https://github.com/user-attachments/assets/6e4c0f5a-eacb-4d35-a2ef-ca056063f574)
