### PR TITLE
feat(mp-alipay): showToast api 支持 image 和 mask 属性

### DIFF
--- a/packages/uni-mp-alipay/__tests__/api.spec.ts
+++ b/packages/uni-mp-alipay/__tests__/api.spec.ts
@@ -34,7 +34,12 @@ global.my = {
   }),
 }
 
-import { request, showModal } from '../src/api/protocols'
+import {
+  request,
+  showLoading,
+  showModal,
+  showToast,
+} from '../src/api/protocols'
 
 describe('api', () => {
   test('api-request base', () => {
@@ -194,5 +199,91 @@ describe('api', () => {
 
     expect(args.cancelColor).toBe(false)
     expect(args.confirmColor).toBe(false)
+  })
+
+  test('api-alipay showLoading', () => {
+    global.my.canIUse = jest.fn().mockImplementation((api) => {
+      if (api === 'showLoading.object.mask') {
+        return true
+      }
+      return true
+    })
+
+    expect(showLoading.args).toEqual({
+      title: 'content',
+      mask: 'mask',
+    })
+  })
+
+  test('api-dingding showLoading', () => {
+    global.my.canIUse = jest.fn().mockImplementation((api) => {
+      if (api === 'showLoading.object.mask') {
+        return false
+      }
+      return true
+    })
+
+    expect(showLoading.args.mask).toBe(false)
+    expect(showLoading.args.title).toBe('content')
+  })
+
+  test('api-alipay showToast', () => {
+    global.my.canIUse = jest.fn().mockImplementation((api) => {
+      if (api === 'showToast') {
+        return true
+      }
+      return true
+    })
+
+    expect(typeof showToast).toBe('function')
+    const loadingArgs = showToast({ icon: 'loading' }) as any
+
+    expect(loadingArgs.name).toEqual('showLoading')
+    expect(loadingArgs.args).toEqual({
+      title: 'content',
+      mask: 'mask',
+    })
+
+    const toastArgs = showToast() as any
+
+    expect(toastArgs.name).toEqual('showToast')
+    expect(toastArgs.args).toEqual({
+      icon: 'type',
+      title: 'content',
+      mask: 'mask',
+      image: 'image',
+    })
+  })
+
+  test('api-dingding showToast', () => {
+    global.my.canIUse = jest.fn().mockImplementation((api) => {
+      if (
+        api === 'showLoading.object.mask' ||
+        api === 'showToast.object.image' ||
+        api === 'showToast.object.mask'
+      ) {
+        return false
+      }
+      return true
+    })
+
+    expect(typeof showToast).toBe('function')
+    const loadingArgs = showToast({ icon: 'loading' }) as any
+
+    expect(loadingArgs.name).toEqual('showLoading')
+    expect(loadingArgs.args).toEqual({
+      title: 'content',
+      mask: false,
+    })
+
+    const toastArgs = showToast() as any
+
+    expect(toastArgs.name).toEqual('showToast')
+    expect(toastArgs.args).toEqual({
+      icon: 'type',
+      title: 'content',
+      mask: false,
+      image: false,
+    })
   })
 })

--- a/packages/uni-mp-alipay/src/api/protocols.ts
+++ b/packages/uni-mp-alipay/src/api/protocols.ts
@@ -1,4 +1,4 @@
-import { hasOwn, isArray, isPlainObject } from '@vue/shared'
+import { extend, hasOwn, isArray, isPlainObject } from '@vue/shared'
 
 import {
   navigateTo as _navigateTo,
@@ -200,19 +200,22 @@ export function showModal({ showCancel = true }: UniApp.ShowModalOptions = {}) {
 export function showToast({ icon = 'success' }: UniApp.ShowToastOptions = {}) {
   const args = {
     title: 'content',
-    icon: 'type',
-    image: false,
-    mask: false,
   }
   if (icon === 'loading') {
     return {
       name: 'showLoading',
-      args,
+      args: extend(
+        { mask: my.canIUse('showLoading.object.mask') ? 'mask' : false },
+        args
+      ),
     }
   }
   return {
     name: 'showToast',
-    args,
+    args: extend({ icon: 'type' }, args, {
+      mask: my.canIUse('showToast.object.mask') ? 'mask' : false,
+      image: my.canIUse('showToast.object.image') ? 'image' : false,
+    }),
   }
 }
 export const showActionSheet = {
@@ -228,6 +231,7 @@ export const showActionSheet = {
 export const showLoading = {
   args: {
     title: 'content',
+    mask: my.canIUse('showLoading.object.mask') ? 'mask' : false,
   },
 }
 export const uploadFile = {

--- a/packages/uni-mp-compiler/src/template/codegen.ts
+++ b/packages/uni-mp-compiler/src/template/codegen.ts
@@ -1,4 +1,4 @@
-import { hyphenate, isFunction, isPlainObject, extend } from '@vue/shared'
+import { extend, hyphenate, isFunction, isPlainObject } from '@vue/shared'
 import {
   SLOT_DEFAULT_NAME,
   VIRTUAL_HOST_CLASS,


### PR DESCRIPTION
支付宝已支持以上两个属性，[相关文档](https://opendocs.alipay.com/mini/api/fhur8f?pathHash=8710cb95#my.showToast(Object%20object))

![image](https://github.com/user-attachments/assets/a6958d3e-be5d-4c81-837f-51552c19e1c7)
