### PR TITLE
fix(web): 修复 showModal 设置 editable 为 true 时单行中文内容出现滚动条的问题

### DIFF
--- a/packages/uni-h5/style/api/modal.css
+++ b/packages/uni-h5/style/api/modal.css
@@ -69,6 +69,8 @@ uni-modal {
   border: none;
   background-color: #eee;
   text-decoration: inherit;
+  /* 解决单行中文内容会出现滚动条的问题 */
+  line-height: 1.2;
 }
 
 .uni-modal__ft {


### PR DESCRIPTION
# 问题截图

![钉钉录屏_2025-06-12 153704](https://github.com/user-attachments/assets/56cf06af-f365-4fc7-858e-87861d007807)

# 修复效果

![image](https://github.com/user-attachments/assets/ae6b0ca2-04c4-46e1-bd40-67d04b29963f)
