### PR TITLE
fix(mp): 修复插槽默认内容编译不生效的bug (question/210538)

### DIFF
--- a/packages/uni-mp-alipay/__tests__/vSlot.spec.ts
+++ b/packages/uni-mp-alipay/__tests__/vSlot.spec.ts
@@ -4,7 +4,7 @@ describe('mp-alipay: transform v-slot', () => {
   test('default slot', () => {
     assert(
       `<custom><template v-slot/></custom>`,
-      `<custom u-s="{{['d']}}" u-i="2a9ec0b0-0" onVI="__l"><view/></custom>`,
+      `<custom u-i="2a9ec0b0-0" onVI="__l"></custom>`,
       `(_ctx, _cache) => {
   return {}
 }`
@@ -20,7 +20,7 @@ describe('mp-alipay: transform v-slot', () => {
   test('named slots', () => {
     assert(
       `<custom><template v-slot:header/><template v-slot:default/><template v-slot:footer/></custom>`,
-      `<custom u-s="{{['header','d','footer']}}" u-i="2a9ec0b0-0" onVI="__l"><view slot="header"/><view/><view slot="footer"/></custom>`,
+      `<custom u-i="2a9ec0b0-0" onVI="__l"></custom>`,
       `(_ctx, _cache) => {
   return {}
 }`

--- a/packages/uni-mp-baidu/__tests__/vSlot.spec.ts
+++ b/packages/uni-mp-baidu/__tests__/vSlot.spec.ts
@@ -4,7 +4,7 @@ describe('compiler: transform v-slot', () => {
   test('default slot', () => {
     assert(
       `<custom><template v-slot/></custom>`,
-      `<custom u-s="{{['d']}}" u-i="2a9ec0b0-0"><view/></custom>`,
+      `<custom u-i="2a9ec0b0-0"></custom>`,
       `(_ctx, _cache) => {
   return {}
 }`
@@ -20,7 +20,7 @@ describe('compiler: transform v-slot', () => {
   test('named slots', () => {
     assert(
       `<custom><template v-slot:header/><template v-slot:default/><template v-slot:footer/></custom>`,
-      `<custom u-s="{{['header','d','footer']}}" u-i="2a9ec0b0-0"><view slot="header"/><view/><view slot="footer"/></custom>`,
+      `<custom u-i="2a9ec0b0-0"></custom>`,
       `(_ctx, _cache) => {
   return {}
 }`

--- a/packages/uni-mp-compiler/__tests__/vFor.spec.ts
+++ b/packages/uni-mp-compiler/__tests__/vFor.spec.ts
@@ -220,8 +220,8 @@ describe(`compiler: v-for`, () => {
     // 1637
     test(`v-if + v-for on <template>`, () => {
       assert(
-        `<template v-if="ok" v-for="i in list"/>`,
-        `<block wx:if="{{a}}"><block wx:for="{{b}}" wx:for-item="i"/></block>`,
+        `<template v-if="ok" v-for="i in list"><view>1</view></template>`,
+        `<block wx:if="{{a}}"><block wx:for="{{b}}" wx:for-item="i"><view>1</view></block></block>`,
         `(_ctx, _cache) => {
   return _e({ a: _ctx.ok }, _ctx.ok ? { b: _f(_ctx.list, (i, k0, i0) => { return {}; }) } : {})
 }`

--- a/packages/uni-mp-compiler/__tests__/vSlot.spec.ts
+++ b/packages/uni-mp-compiler/__tests__/vSlot.spec.ts
@@ -4,14 +4,14 @@ describe('compiler: transform v-slot', () => {
   test('default slot', () => {
     assert(
       `<custom><template v-slot/></custom>`,
-      `<custom u-s="{{['d']}}" u-i="2a9ec0b0-0"><view/></custom>`,
+      `<custom u-i="2a9ec0b0-0"></custom>`,
       `(_ctx, _cache) => {
   return {}
 }`
     )
     assert(
       `<custom><template #default/></custom>`,
-      `<custom u-s="{{['d']}}" u-i="2a9ec0b0-0"><view/></custom>`,
+      `<custom u-i="2a9ec0b0-0"></custom>`,
       `(_ctx, _cache) => {
   return {}
 }`
@@ -34,7 +34,7 @@ describe('compiler: transform v-slot', () => {
   test('named slots', () => {
     assert(
       `<custom><template v-slot:header/><template v-slot:default/><template v-slot:footer/></custom>`,
-      `<custom u-s="{{['header','d','footer']}}" u-i="2a9ec0b0-0"><view slot="header"/><view/><view slot="footer"/></custom>`,
+      `<custom u-i="2a9ec0b0-0"></custom>`,
       `(_ctx, _cache) => {
   return {}
 }`
@@ -132,4 +132,54 @@ describe('compiler: transform v-slot', () => {
 }`
     )
   })
+})
+
+describe('should remove template when it has no any child nodes or all of its child nodes are comment nodes', () => {
+  assert(
+    `<custom><template #header /></custom>`,
+    `<custom u-i="2a9ec0b0-0"></custom>`,
+    `(_ctx, _cache) => {
+  return {}
+}`
+  )
+
+  assert(
+    `<custom><template #header><!-- comment --></template></custom>`,
+    `<custom u-i="2a9ec0b0-0"></custom>`,
+    `(_ctx, _cache) => {
+  return {}
+}`
+  )
+
+  assert(
+    `<custom><template v-slot:header="{}" /></custom>`,
+    `<custom u-i="2a9ec0b0-0"></custom>`,
+    `(_ctx, _cache) => {
+  return {}
+}`
+  )
+
+  assert(
+    `<custom><template /></custom><custom><template #header /></custom>`,
+    `<custom u-i="2a9ec0b0-0"></custom><custom u-i="2a9ec0b0-1"></custom>`,
+    `(_ctx, _cache) => {
+  return {}
+}`
+  )
+
+  assert(
+    `<custom><template>hello</template></custom><custom><template #header /></custom>`,
+    `<custom u-s="{{['d']}}" u-i="2a9ec0b0-0"><block u-s="{{['d']}}">hello</block></custom><custom u-i="2a9ec0b0-1"></custom>`,
+    `(_ctx, _cache) => {
+  return {}
+}`
+  )
+
+  assert(
+    `<custom><template v-slot:default="slotProps"><view>{{ slotProps.item }}</view></template><template #header /></custom>`,
+    `<custom u-s="{{['d']}}" u-i="2a9ec0b0-0"><view wx:for="{{a}}" wx:for-item="slotProps" wx:key="b" slot="{{slotProps.c}}"><view>{{slotProps.a}}</view></view></custom>`,
+    `(_ctx, _cache) => {
+  return { a: _w((slotProps, s0, i0) => { return { a: _t(slotProps.item), b: i0, c: s0 }; }, { name: 'd', path: 'a', vueId: '2a9ec0b0-0' }) }
+}`
+  )
 })

--- a/packages/uni-mp-compiler/src/transforms/vSlot.ts
+++ b/packages/uni-mp-compiler/src/transforms/vSlot.ts
@@ -63,6 +63,17 @@ export const transformSlot: NodeTransform = (node, context) => {
   const isMiniProgramComponent = context.isMiniProgramComponent(tag)
   for (let i = 0; i < children.length; i++) {
     const slotElement = children[i]
+    if (
+      slotElement.type === NodeTypes.ELEMENT &&
+      slotElement.tag === 'template' &&
+      slotElement.children.filter((node) => node.type !== NodeTypes.COMMENT)
+        .length === 0
+    ) {
+      // 如果是 template 且 没有子节点 或者 子节点 都是 注释节点，直接移除节点
+      children.splice(i, 1)
+      i -= 1
+      continue
+    }
     let slotDir: DirectiveNode | undefined
     if (
       !isTemplateNode(slotElement) ||
@@ -130,7 +141,6 @@ export const transformSlot: NodeTransform = (node, context) => {
     const slotsArr = [...slots]
     const hasDynamic = slotsArr.find((name) => !isString(name))
     let value: string | ExpressionNode
-
     if (hasDynamic) {
       const children: (string | ExpressionNode)[] = []
       const len = slotsArr.length - 1


### PR DESCRIPTION
# 社区帖子

[https://ask.dcloud.net.cn/question/210538](https://ask.dcloud.net.cn/question/210538)

# 测试代码

```vue
<template>
  <view>
    <Test>
      <template #header></template>
      <template></template>
      <template v-slot:footer> </template>
      <template v-slot:a="{ a }"></template>
      <template #left>left</template>
      <template v-slot:right="{ }">right</template>
    </Test>
  </view>
</template>
```

# 编译效果

```vue
<view class="{{[virtualHostClass]}}" style="{{virtualHostStyle}}" hidden="{{virtualHostHidden || false}}" id="{{c}}">
  <test u-s="{{['left','right']}}" u-i="bf84929c-0" bind:__l="__l">
    <view slot="left">left</view>
    <view wx:for="{{b}}" wx:for-item="v0" wx:key="a" slot="{{v0.b}}">right</view>
  </test>
</view>
```
