### PR TITLE
支持原生鸿蒙UA，否则纯血鸿蒙手机下_isMobile 返回非预期的 false

### DIFF
--- a/packages/uni-components/lib/ad/ad.mixin.web.js
+++ b/packages/uni-components/lib/ad/ad.mixin.web.js
@@ -146,7 +146,7 @@ export default {
     },
 
     _isMobile () {
-      return /android|iphone/i.test(navigator.userAgent.toLowerCase())
+      return /android|phone/i.test(navigator.userAgent.toLowerCase())
     },
 
     _onmpload (e) {


### PR DESCRIPTION
举例说明：
Mozilla/5.0 (Phone; OpenHarmony 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36  ArkWeb/4.1.6.1 Mobile
```javascript
// iphone return true
/android|phone/i.test('mozilla/5.0 (iphone; cpu iphone os 16_6 like mac os x) applewebkit/605.1.15 (khtml, like gecko) version/16.6 mobile/15e148 safari/604.1')
// openharmony  return true
/android|phone/i.test('mozilla/5.0 (phone; openharmony 5.0) applewebkit/537.36 (khtml, like gecko) chrome/114.0.0.0 safari/537.36  arkweb/4.1.6.1 mobile')
```