### PR TITLE
fix(mp-alipay): 修复双层 for 循环在编译后仅生成单层 for 的 bug (question/210636)

### DIFF
--- a/packages/uni-template-compiler/__tests__/compiler-mp-alipay.spec.js
+++ b/packages/uni-template-compiler/__tests__/compiler-mp-alipay.spec.js
@@ -15,10 +15,24 @@ function assertCodegen (template, templateCode, renderCode = 'with(this){}', mpO
 }
 
 describe('mp:compiler-mp-alipay', () => {
+  it('generate template + v-for directive', () => {
+    assertCodegen(
+      '<view><template v-for="(item,index) in items" :key="index">hello</template></view>',
+      '<view><block a:for="{{items}}" a:for-item="item" a:for-index="index">hello</block></view>'
+    )
+  })
+
   it('generate v-for directive', () => {
     assertCodegen(
       '<view><view v-for="(item,index) in items" :key="index"></view></view>',
       '<view><view a:for="{{items}}" a:for-item="item" a:for-index="index" a:key="index"></view></view>'
+    )
+  })
+
+  it('generate v-for + v-for directive', () => {
+    assertCodegen(
+      '<template v-for="item in list"><view v-for="(val, idx) in item.value" :key="idx">{{ item.key }} -- {{ val }}</view></template>',
+      '<block a:for="{{list}}" a:for-item="item" a:for-index="__i0__" a:key="*this"><view a:for="{{item.value}}" a:for-item="val" a:for-index="idx" a:key="idx">{{item.key+" -- "+val}}</view></block>'
     )
   })
 

--- a/packages/uni-template-compiler/lib/template/traverse.js
+++ b/packages/uni-template-compiler/lib/template/traverse.js
@@ -564,7 +564,8 @@ function traverseRenderList (callExprNode, state) {
     children.type) {
     children.attr = children.attr || {}
     Object.assign(children.attr, attr)
-    return children
+    // 避免 <template v-for><view v-for></view></template> 编译异常
+    return normalizeChildren(children)
   }
   return {
     type: 'block',


### PR DESCRIPTION
# 社区帖子

[https://ask.dcloud.net.cn/question/210636](https://ask.dcloud.net.cn/question/210636)

# 测试代码

```vue
<template>
    <view class="wrapper">
        <template v-for="item in list">
            <view v-for="(val, idx) in item.value" :key="idx">{{ item.key }} -- {{ val }}</view>
        </template>
    </view>
</template>

<script>
    export default {
        data() {
            return {
                list: [{
                        key: "key1",
                        value: [1, 2, 3],
                    },
                    {
                        key: "key2",
                        value: [4, 5, 6],
                    },
                ]
            }
        },
    }
</script>

<style scoped>
    .wrapper {
        padding: 200rpx;
        font-size: 32rpx;
    }
</style>
```
# 编译效果

```vue
<view class="wrapper data-v-57280228">
    <view class="data-v-57280228" a:for="{{list}}" a:for-item="item" a:for-index="__i0__" a:key="*this">
        {{item.key+" -- "+val}}
    </view>
</view>
```

# 修复后编译效果

```vue
<view class="wrapper data-v-57280228">
    <block a:for="{{list}}" a:for-item="item" a:for-index="__i0__" a:key="*this">
        <view class="data-v-57280228" a:for="{{item.value}}" a:for-item="val" a:for-index="idx" a:key="idx">
            {{item.key+" -- "+val}}
        </view>
    </block>
</view>
```