### PR TITLE
fix(mp-weixin): 修复 manifest.json 中 watchOptions 配置未同步到 project.config…

### DIFF
--- a/packages/uni-cli-shared/__tests__/parseMiniProgramProjectJson.spec.ts
+++ b/packages/uni-cli-shared/__tests__/parseMiniProgramProjectJson.spec.ts
@@ -33,6 +33,9 @@ const userManifestJSON: any = {
     },
     usingComponents: true,
     mockFeature: 'enable',
+    watchOptions: {
+      ignore: ['utils/util.js'],
+    },
   },
   'mp-alipay': {
     usingComponents: true,
@@ -159,6 +162,9 @@ describe('parseMiniProgramProjectJson', () => {
       projectname: userManifestJSON.name,
       libVersion: (userManifestJSON[platfrom] as any)?.libVersion || '',
       condition: mpXhsConfig.condition,
+      watchOptions: {
+        ignore: ['utils/util.js'],
+      },
     })
 
     expect(projectJson.hasOwnProperty('mockFeature')).toBe(false)

--- a/packages/uni-cli-shared/src/json/mp/project.ts
+++ b/packages/uni-cli-shared/src/json/mp/project.ts
@@ -28,6 +28,7 @@ export const projectKeys = [
   'debugOptions',
   'scripts',
   'cloudbaseRoot',
+  'watchOptions',
 ]
 
 export function isMiniProgramProjectJsonKey(name: string) {


### PR DESCRIPTION
….json 的bug (question/210856)

# 社区帖子

[https://ask.dcloud.net.cn/question/210856](https://ask.dcloud.net.cn/question/210856)