### PR TITLE
fix(uni-mp-vite): 无法正确处理小程序平台的css文件后缀名

### DIFF
--- a/packages/uni-mp-vite/src/plugin/configResolved.ts
+++ b/packages/uni-mp-vite/src/plugin/configResolved.ts
@@ -212,21 +212,24 @@ export function createConfigResolved({
 function adjustCssExtname(extname: string): Plugin {
   return {
     name: 'uni:adjust-css-extname',
-    generateBundle(_, bundle) {
-      const files = Object.keys(bundle)
-      files.forEach((name) => {
-        if (name.endsWith('.css')) {
-          const asset = bundle[name] as EmittedAsset
-          isString(asset.source) &&
-            (asset.source = asset.source.replace(/\*\,/g, 'page,'))
-          this.emitFile({
-            fileName: name.replace('.css', extname),
-            type: 'asset',
-            source: asset.source,
-          })
-          delete bundle[name]
-        }
-      })
+    generateBundle: {
+      order: 'post',
+      handler(_, bundle) {
+        const files = Object.keys(bundle)
+        files.forEach((name) => {
+          if (name.endsWith('.css')) {
+            const asset = bundle[name] as EmittedAsset
+            isString(asset.source) &&
+              (asset.source = asset.source.replace(/\*\,/g, 'page,'))
+            this.emitFile({
+              fileName: name.replace('.css', extname),
+              type: 'asset',
+              source: asset.source,
+            })
+            delete bundle[name]
+          }
+        })
+      },
     },
   }
 }


### PR DESCRIPTION
close #5604

自 unocss@66.1.0-beta.11 开始, 其内部移除了 unocss:global:build:bundle 插件, 使得当插入 uni:adjust-css-extname 插件时所依赖的插件成为了 unocss:global:build:generate, 造成无法获取 css 文件(此时 vite 内部还没有在 rollup 输出中添加 css 文件, 需要等到 vite:css-post 插件后), 因此这里直接使插件 uni:adjust-css-extname 的 generateBundle 钩子的排序为 post, 以便顺利获取到输出流程中的 css 文件进行处理