### PR TITLE
fix: 修复[移动端h5]picker-view 滑动会出现不能归位的情况

### DIFF
--- a/packages/uni-components/src/helpers/scroller/Scroller.ts
+++ b/packages/uni-components/src/helpers/scroller/Scroller.ts
@@ -216,7 +216,7 @@ export class Scroller {
         const e = Date.now()
         const i = (e - this._scroll._startTime) / 1e3
         const r = this._scroll.x(i)
-        this._position = r
+        this._position = r < -this._extent ? -this._extent : r
         this.updatePosition()
         const o = this._scroll.dx(i)
         if (


### PR DESCRIPTION
修复picker-view 滑动会出现不能归位的情况

https://github.com/user-attachments/assets/c7e6e906-f4d1-46b7-9fb4-9473d96b3871

