### PR TITLE
fix(mp): 修复多个子包引用相同图片时 Vite 默认优化导致路径被合并的问题 (question/194903)

### DIFF
--- a/packages/uni-cli-shared/src/env/define.ts
+++ b/packages/uni-cli-shared/src/env/define.ts
@@ -7,7 +7,8 @@ export function initDefine(stringifyBoolean: boolean = false) {
   const isRunByHBuilderX = runByHBuilderX()
   const isDebug = !!manifestJson.debug
   const isX = process.env.UNI_APP_X === 'true'
-  const isMP = process.env.UNI_PLATFORM.startsWith('mp')
+  const isMP =
+    process.env.UNI_PLATFORM && process.env.UNI_PLATFORM.startsWith('mp-')
 
   process.env['UNI_APP_ID'] = manifestJson.appid
 

--- a/packages/uni-cli-shared/src/vite/plugins/vitejs/plugins/static.ts
+++ b/packages/uni-cli-shared/src/vite/plugins/vitejs/plugins/static.ts
@@ -19,11 +19,17 @@ export function createIsStaticFile() {
         return normalizePath(path.join(subPackage.root, 'static')) + '/'
       })
   }
-  return function isStaticFile(relativeFile: string): boolean {
+  return function isStaticFile(
+    relativeFile: string,
+    onlySubPackages = false // 是否只判断子包 static 下的文件
+  ): boolean {
     if (path.isAbsolute(relativeFile)) {
       relativeFile = normalizePath(
         path.relative(process.env.UNI_INPUT_DIR, relativeFile)
       )
+    }
+    if (onlySubPackages) {
+      return subPackageStatics.some((s) => relativeFile.startsWith(s))
     }
     return (
       relativeFile.startsWith('static/') ||
@@ -33,7 +39,9 @@ export function createIsStaticFile() {
   }
 }
 
-let isStaticFile: (file: string) => boolean
+export type IsStaticFile = (file: string, onlySubPackages?: boolean) => boolean
+
+let isStaticFile: IsStaticFile
 export function getIsStaticFile() {
   if (!isStaticFile) {
     isStaticFile = createIsStaticFile()


### PR DESCRIPTION
# Ask 社区帖子

[https://ask.dcloud.net.cn/question/194903](https://ask.dcloud.net.cn/question/194903)