### PR TITLE
fix(mp-kuaishou): 移除 project.config.json 中无用的 condition 配置

### DIFF
--- a/packages/uni-mp-kuaishou/src/compiler/project.config.json
+++ b/packages/uni-mp-kuaishou/src/compiler/project.config.json
@@ -39,31 +39,5 @@
   },
   "scripts": {},
   "isGameTourist": false,
-  "simulatorPluginLibVersion": {},
-  "condition": {
-    "search": {
-      "current": -1,
-      "list": []
-    },
-    "conversation": {
-      "current": -1,
-      "list": []
-    },
-    "game": {
-      "current": -1,
-      "list": []
-    },
-    "plugin": {
-      "current": -1,
-      "list": []
-    },
-    "gamePlugin": {
-      "current": -1,
-      "list": []
-    },
-    "miniprogram": {
-      "current": -1,
-      "list": []
-    }
-  }
+  "simulatorPluginLibVersion": {}
 }


### PR DESCRIPTION
# 文档

快手的配置文件，只有私有配置文件才支持 `condition` 字段

![Uploading image.png…]()

[https://open.kuaishou.com/docs/develop/developerTools/Localization-project.html#支持字段](https://open.kuaishou.com/docs/develop/developerTools/Localization-project.html#支持字段)