### PR TITLE
fix(mp-alipay): 修复 globalStyle 中设置 navigationBarTextStyle 不生效的Bug

### DIFF
--- a/packages/uni-mp-alipay/src/compiler/options.ts
+++ b/packages/uni-mp-alipay/src/compiler/options.ts
@@ -112,6 +112,7 @@ export const options: UniMiniProgramPluginOptions = {
   json: {
     windowOptionsMap: {
       defaultTitle: 'navigationBarTitleText',
+      navigationBarFrontColor: 'navigationBarTextStyle',
       pullRefresh: 'enablePullDownRefresh',
       allowsBounceVertical: 'allowsBounceVertical',
       titleBarColor: 'navigationBarBackgroundColor',


### PR DESCRIPTION
# 支付宝官方文档

<img width="1246" height="593" alt="image" src="https://github.com/user-attachments/assets/3ec45404-693f-4218-b8c5-2452fec73f72" />

[https://opendocs.alipay.com/mini/framework/app-json#window](https://opendocs.alipay.com/mini/framework/app-json#window)