### PR TITLE
fix(mp): 修复类名为变量时未能正确编译的Bug

### DIFF
--- a/packages/uni-template-compiler/__tests__/compiler-extra.spec.js
+++ b/packages/uni-template-compiler/__tests__/compiler-extra.spec.js
@@ -442,6 +442,18 @@ describe('mp:compiler-extra', () => {
       '<view class="{{[\'_div\',(isActive)?\'active\':\'\']}}">1</view>'
     )
     assertCodegen(
+      '<div :class="{ [active]: isActive }">1</div>',
+      `<view class="{{['_div',(isActive)?(active):'']}}">1</view>`
+    )
+    assertCodegen(
+      `<div :class="{ [active ? 'actvieClass' : 'unactiveClass']: isActive }">1</div>`,
+      `<view class="{{['_div',(isActive)?(active?'actvieClass':'unactiveClass'):'']}}">1</view>`
+    )
+    assertCodegen(
+      `<div :class="{ [active ? 'actvieClass' : 'unactiveClass']: isActive, class1: true }">1</div>`,
+      `<view class="{{['_div',(isActive)?(active?'actvieClass':'unactiveClass'):'',(true)?'class1':'']}}">1</view>`
+    )
+    assertCodegen(
       '<p class="static" :class="{ active: isActive, \'text-danger\': hasError }">2</p>',
       '<view class="{{[\'static\',\'_p\',(isActive)?\'active\':\'\',(hasError)?\'text-danger\':\'\']}}">2</view>'
     )

--- a/packages/uni-template-compiler/lib/script/traverse/data/class.js
+++ b/packages/uni-template-compiler/lib/script/traverse/data/class.js
@@ -60,7 +60,7 @@ function processClassObjectExpression (classValuePath) {
     elements.push(
       t.conditionalExpression(
         t.parenthesizedExpression(propertyPath.node.value),
-        t.stringLiteral(key.name || key.value),
+        propertyPath.node.computed ? t.parenthesizedExpression(key) : t.stringLiteral(key.name || key.value),
         t.stringLiteral('')
       )
     )


### PR DESCRIPTION
close #3101 

# 测试代码

```vue
<view :class="{ [test]: true }">Hello {{ test }}</view>
```

# 问题产物

```js
<view class="{{[(true)?'test':'']}}">{{"Hello "+test}}</view>
```

# 修复产物

```js
<view class="{{[(true)?test:'']}}">{{"Hello "+test}}</view>
```