### PR TITLE
fix(mp): 修复 wxs 中动态绑定 class 不生效的Bug

### DIFF
--- a/packages/uni-mp-compiler/__tests__/wxs.spec.ts
+++ b/packages/uni-mp-compiler/__tests__/wxs.spec.ts
@@ -14,6 +14,67 @@ describe('compiler: transform wxs', () => {
       }
     )
   })
+  test('class', () => {
+    assert(
+      `<view :class="utils.formatClass('hello')"><view class="test"></view></view>`,
+      `<view class="{{utils.formatClass('hello')}}"><view class="test"></view></view>`,
+      `(_ctx, _cache) => {
+  return {}
+}`,
+      {
+        filters: ['utils'],
+        cacheHandlers: true,
+      }
+    )
+    assert(
+      `<view :class="formatClass('hello')" class="test1"><view class="test"></view></view>`,
+      `<view class="{{[a, 'test1']}}"><view class="test"></view></view>`,
+      `(_ctx, _cache) => {
+  return { a: _ctx.formatClass('hello') }
+}`,
+      {
+        filters: ['utils'],
+        cacheHandlers: true,
+      }
+    )
+    assert(
+      `<view :class="[utils.formatClass('hello'), 'hello1', utils.formatClass('hello2'), normalizeClass('hello3')]"><view class="test"></view></view>`,
+      `<view class="{{[utils.formatClass('hello'), 'hello1', utils.formatClass('hello2'), a]}}"><view class="test"></view></view>`,
+      `(_ctx, _cache) => {
+  return { a: _ctx.normalizeClass('hello3') }
+}`,
+      {
+        filters: ['utils'],
+        cacheHandlers: true,
+      }
+    )
+    assert(
+      `<view :class="utils.formatClass('hello')"><view class="test"></view></view>`,
+      `<view class="{{utils.formatClass('hello')}}"><view class="test"></view></view>`,
+      `(_ctx, _cache) => { "raw js"
+  const __returned__ = {}
+  return __returned__
+}`,
+      {
+        filters: ['utils'],
+        cacheHandlers: true,
+        isX: true,
+      }
+    )
+    assert(
+      `<view :class="[utils.formatClass('hello'), 'hello1', utils.formatClass('hello2'), normalizeClass('hello3')]"><view class="test"></view></view>`,
+      `<view class="{{[utils.formatClass('hello'), 'hello1', utils.formatClass('hello2'), a]}}"><view class="test"></view></view>`,
+      `(_ctx, _cache) => { "raw js"
+  const __returned__ = { a: _ctx.normalizeClass('hello3') }
+  return __returned__
+}`,
+      {
+        filters: ['utils'],
+        isX: true,
+        cacheHandlers: true,
+      }
+    )
+  })
   test('cacheHandlers', () => {
     assert(
       `<view :data-threshold="threshold" :change:prop="swipe.showWatch" :prop="is_show" @touchstart="swipe.touchstart"/>`,

--- a/packages/uni-mp-compiler/src/transforms/transformClass.ts
+++ b/packages/uni-mp-compiler/src/transforms/transformClass.ts
@@ -163,14 +163,10 @@ function rewriteClassExpression(
   expr: ExpressionNode,
   context: TransformContext
 ) {
-  return rewriteExpression(
-    createCompoundExpression([
-      context.helperString(NORMALIZE_CLASS) + '(',
-      expr,
-      ')',
-    ]),
-    context
-  )
+  const expressions = context.filters.length
+    ? [expr]
+    : [context.helperString(NORMALIZE_CLASS) + '(', expr, ')']
+  return rewriteExpression(createCompoundExpression(expressions), context)
 }
 
 function rewriteClassArrayExpression(


### PR DESCRIPTION
# 测试代码

```vue
<template>
	<view class="page">
		<view :class="utils.cls('l-checkbox', [
			['checked', true]
		])">
		   <text>{{utils.cls('l-checkbox', [
			['checked', true]
		])}}</text>
		</view>
	</view>
</template>

<script lang="wxs" src="./utils.wxs" module="utils"></script>

<style lang="scss">
	.l-checkbox {
		background-color: red;
		height: 500px;
		width: 500px;
	}
</style>
```

```js
function cls(base, arr) {
	var res = [base];
	var i = 0;
	for (var size = arr.length; i < size; i++) {
		var item = arr[i];
		if (item && item.constructor === 'Array') {
			var key = arr[i][0];
			var value = arr[i][1];
			if (value) {
				res.push(base + '--' + key);
			}
		} else if (typeof item === 'string' || typeof item === 'number') {
			if (item) {
				res.push(base + '--' + item);
			}
		}
	}
	return res.join(' ');
}


module.exports = {
  cls: cls
};
```

# 效果

样式没生效

![before](https://github.com/user-attachments/assets/a47465ed-d2df-4ec6-a289-4143588b5030)

# 修复后效果

![after](https://github.com/user-attachments/assets/68028999-007e-4227-a689-f5baeb3e53b2)

