### PR TITLE
fix(mp): 修复设置 mergeVirtualHostAttributes: true 时带有 v-for 的子节点也会添加虚拟属性…

### DIFF
--- a/packages/uni-template-compiler/__tests__/compiler-mp-merge-virtual-host-attributes.spec.js
+++ b/packages/uni-template-compiler/__tests__/compiler-mp-merge-virtual-host-attributes.spec.js
@@ -1,0 +1,109 @@
+const compiler = require("../lib");
+
+function assertCodegen(template, templateCode, renderCode = "with(this){}") {
+  const res = compiler.compile(template, {
+    resourcePath: "test.wxml",
+    mp: Object.assign(
+      {
+        minified: true,
+        isTest: true,
+        platform: "mp-weixin"
+      },
+      { mergeVirtualHostAttributes: true }
+    )
+  });
+
+  expect(res.template).toBe(templateCode);
+
+  if (typeof renderCode === "function") {
+    renderCode(res);
+  } else {
+    expect(res.render).toBe(renderCode);
+  }
+}
+
+describe("compiler-mp-merge-virtual-host-attributes", () => {
+  test("root node class", () => {
+    assertCodegen(
+      '<view class="red blue"><text>hello world</text></view>',
+      `<view class="{{['red','blue',virtualHostClass]}}" style="{{virtualHostStyle}}"><text>hello world</text></view>`
+    );
+
+    assertCodegen(
+      '<view class="red blue"></view>',
+      `<view class="{{['red','blue',virtualHostClass]}}" style="{{virtualHostStyle}}"></view>`
+    );
+
+    assertCodegen(
+      '<view :class="class1"><text>hello world</text></view>',
+      `<view class="{{[class1,virtualHostClass]}}" style="{{virtualHostStyle}}"><text>hello world</text></view>`
+    );
+
+    assertCodegen(
+      '<view class="red blue" :class="class1"><text>hello world</text></view>',
+      `<view class="{{['red','blue',class1,virtualHostClass]}}" style="{{virtualHostStyle}}"><text>hello world</text></view>`
+    );
+
+    assertCodegen(
+      '<view class="red blue" :class="{ class1: true }"><text>hello world</text></view>',
+      `<view class="{{['red','blue',(true)?'class1':'',virtualHostClass]}}" style="{{virtualHostStyle}}"><text>hello world</text></view>`
+    );
+  });
+
+  test("root node style", () => {
+    assertCodegen(
+      '<view style="color: red"><text>hello world</text></view>',
+      `<view class="{{[virtualHostClass]}}" style="{{'color:red;'+(virtualHostStyle||'')}}"><text>hello world</text></view>`
+    );
+
+    assertCodegen(
+      '<view style="color: red"></view>',
+      `<view class="{{[virtualHostClass]}}" style="{{'color:red;'+(virtualHostStyle||'')}}"></view>`
+    );
+
+    assertCodegen(
+      '<view style="color: red" :style="style1"><text>hello world</text></view>',
+      `<view style="{{'color:red;'+(style1)+virtualHostStyle}}" class="{{[virtualHostClass]}}"><text>hello world</text></view>`
+    );
+  });
+
+  test("root node class and style", () => {
+    assertCodegen(
+      '<view class="red blue" style="color: red"><text>hello world</text></view>',
+      `<view class="{{['red','blue',virtualHostClass]}}" style="{{'color:red;'+(virtualHostStyle||'')}}"><text>hello world</text></view>`
+    );
+
+    assertCodegen(
+      '<view class="red blue" style="color: red" :style="style1"><text>hello world</text></view>',
+      `<view style="{{'color:red;'+(style1)+virtualHostStyle}}" class="{{['red','blue',virtualHostClass]}}"><text>hello world</text></view>`
+    );
+
+    assertCodegen(
+      '<view class="red blue" style="color: red" :class="class1"><text>hello world</text></view>',
+      `<view class="{{['red','blue',class1,virtualHostClass]}}" style="{{'color:red;'+(virtualHostStyle||'')}}"><text>hello world</text></view>`
+    );
+
+    assertCodegen(
+      '<view class="red blue" style="color: red" :class="class1" :style="style1"><text>hello world</text></view>',
+      `<view class="{{['red','blue',class1,virtualHostClass]}}" style="{{'color:red;'+(style1)+virtualHostStyle}}"><text>hello world</text></view>`
+    );
+  });
+
+  test("child node with v-for directive", () => {
+    assertCodegen(
+      '<view><text v-for="item in 3" :key="item">hello world {{ item }}</text></view>',
+      `<view class="{{[virtualHostClass]}}" style="{{virtualHostStyle}}"><block wx:for="{{3}}" wx:for-item="item" wx:for-index="__i0__" wx:key="*this"><text>{{"hello world "+item}}</text></block></view>`
+    );
+
+    assertCodegen(
+      '<view><text v-for="item in 3" :key="item" style="color: red" class="blue">hello world {{ item }}</text></view>',
+      `<view class="{{[virtualHostClass]}}" style="{{virtualHostStyle}}"><block wx:for="{{3}}" wx:for-item="item" wx:for-index="__i0__" wx:key="*this"><text class="blue" style="color:red;">{{"hello world "+item}}</text></block></view>`
+    );
+
+    assertCodegen(
+      `<view><text v-for="item in 3" :key="item" :style="{ color: 'red' }" :class="{ 'blue': true }">hello world {{ item }}</text></view>`,
+      `<view class="{{[virtualHostClass]}}" style="{{virtualHostStyle}}"><block wx:for="{{3}}" wx:for-item="item" wx:for-index="__i0__" wx:key="*this"><text class="{{[(true)?'blue':'']}}" style="{{'color:'+('red')+';'}}">{{"hello world "+item}}</text></block></view>`
+    );
+  });
+});
+

--- a/packages/uni-template-compiler/lib/script/traverse/data/class.js
+++ b/packages/uni-template-compiler/lib/script/traverse/data/class.js
@@ -7,7 +7,8 @@ const {
 
 const {
   getCode,
-  isRootElement
+  isRootElement,
+  isVForElement
 } = require('../../../util')
 
 function processClassArrayExpressionElements (classArrayExpression) {
@@ -124,7 +125,7 @@ module.exports = function processClass (paths, path, state) {
       state.errors.add(':class' + uniI18n.__('templateCompiler.noSupportSyntax', { 0: getCode(classValuePath.node) }))
     }
   }
-  if (mergeVirtualHostAttributes && isRootElement(path.parentPath)) {
+  if (mergeVirtualHostAttributes && isRootElement(path.parentPath) && !isVForElement(path.parentPath)) {
     const virtualHostClass = t.identifier(VIRTUAL_HOST_CLASS)
     if (classArrayExpression) {
       classArrayExpression.elements.push(virtualHostClass)

--- a/packages/uni-template-compiler/lib/script/traverse/data/style.js
+++ b/packages/uni-template-compiler/lib/script/traverse/data/style.js
@@ -9,7 +9,8 @@ const {
 const {
   getCode,
   hyphenate,
-  isRootElement
+  isRootElement,
+  isVForElement
 } = require('../../../util')
 
 const getMemberExpr = require('../member-expr')
@@ -182,11 +183,11 @@ module.exports = function processStyle (paths, path, state) {
     } else {
       state.errors.add(`:style 不支持 ${getCode(styleValuePath.node)} 语法`)
     }
-    if (mergeVirtualHostAttributes && isRootElement(path.parentPath)) {
+    if (mergeVirtualHostAttributes && isRootElement(path.parentPath) && !isVForElement(path.parentPath)) {
       styleValuePath.replaceWith(t.binaryExpression('+', styleValuePath.node, t.identifier(VIRTUAL_HOST_STYLE)))
     }
   } else if (staticStylePath) {
-    if (mergeVirtualHostAttributes && isRootElement(path.parentPath)) {
+    if (mergeVirtualHostAttributes && isRootElement(path.parentPath) && !isVForElement(path.parentPath)) {
       const styleNode = processStaticStyle([t.logicalExpression('||', t.identifier(VIRTUAL_HOST_STYLE), t.stringLiteral(''))], staticStylePath, state)
       const property = t.objectProperty(t.identifier('style'), styleNode)
       path.node.properties.push(property)
@@ -194,7 +195,7 @@ module.exports = function processStyle (paths, path, state) {
     }
     staticStylePath.get('value').replaceWith(getStaticStyleStringLiteral(staticStylePath, state))
   } else {
-    if (mergeVirtualHostAttributes && isRootElement(path.parentPath)) {
+    if (mergeVirtualHostAttributes && isRootElement(path.parentPath) && !isVForElement(path.parentPath)) {
       const property = t.objectProperty(t.identifier('style'), t.identifier(VIRTUAL_HOST_STYLE))
       path.node.properties.push(property)
     }

--- a/packages/uni-template-compiler/lib/util.js
+++ b/packages/uni-template-compiler/lib/util.js
@@ -335,6 +335,10 @@ function isRootElement (path) {
   return result.isReturnStatement()
 }
 
+function isVForElement (path) {
+  return path.findParent(path => path.isCallExpression() && path.get('callee').isIdentifier({ name: METHOD_RENDER_LIST }))
+}
+
 /**
  * 事件绑定是否存在成员表达式 => obj.click2()
  * @param {*} path
@@ -389,5 +393,6 @@ module.exports = {
   hasEscapeQuote,
   hasLengthProperty,
   isRootElement,
+  isVForElement,
   hasMemberExpression
 }


### PR DESCRIPTION
…的 Bug (question/212534)

# 测试代码

```html
<view>
   <view v-for="item in 4" :key="item">test: {{ item }}</view>
</view>
```

<img width="1809" height="453" alt="image" src="https://github.com/user-attachments/assets/9799271f-73a7-475d-b5e9-c3b9e05fba14" />

# ask

[https://ask.dcloud.net.cn/question/212534](https://ask.dcloud.net.cn/question/212534)