### PR TITLE
fix(mp-weixin): 修复 movable-view 组件动态绑定 direction 不生效的 Bug

### DIFF
--- a/packages/uni-mp-weixin/__tests__/component.spec.ts
+++ b/packages/uni-mp-weixin/__tests__/component.spec.ts
@@ -191,6 +191,22 @@ describe('mp-weixin: transform component', () => {
 }`
     )
   })
+  test('lazy element: movable-view', () => {
+    assert(
+      `<movable-area><movable-view direction="all">drag me</movable-view></movable-area>`,
+      `<movable-area><movable-view direction="all">drag me</movable-view></movable-area>`,
+      `(_ctx, _cache) => {
+  return {}
+}`
+    )
+    assert(
+      `<movable-area><movable-view :direction="direction">drag me</movable-view></movable-area>`,
+      `<movable-area><block wx:if="{{r0}}"><movable-view direction="{{a}}">drag me</movable-view></block></movable-area>`,
+      `(_ctx, _cache) => {
+  return { a: _ctx.direction }
+}`
+    )
+  })
   test('lazy element: scroll-view', () => {
     assert(
       `<scroll-view/>`,

--- a/packages/uni-mp-weixin/src/compiler/options.ts
+++ b/packages/uni-mp-weixin/src/compiler/options.ts
@@ -118,6 +118,7 @@ export function getMiniProgramOptions(
       // iOS 平台需要延迟
       input: [{ name: 'bind', arg: ['type'] }],
       textarea: [{ name: 'on', arg: ['input'] }],
+      'movable-view': [{ name: 'bind', arg: ['direction'] }],
     },
     component: {
       ':host': true,


### PR DESCRIPTION
close #5694 