### PR TITLE
fix(uni-cli-shared): 修复 pages 页面路径变量重复的问题

### DIFF
--- a/packages/uni-cli-shared/src/utils.ts
+++ b/packages/uni-cli-shared/src/utils.ts
@@ -49,8 +49,9 @@ export function checkElementNodeTag(
  * @returns
  */
 export function normalizeIdentifier(str: string) {
-  let _str = str.replace(/[^a-zA-Z0-9]+/g, '-')
-  _str = capitalize(camelize(_str))
+  // pages/my-book/detail -> pages$my_book$detail
+  // pages-my/book/detail -> pages_my$book$detail
+  let _str = str.replace(/[\\/]/g, '$').replace(/[^a-zA-Z0-9$]+/g, '_');
   // 不允许数字开头，补充 _
   if (/^\d/.test(_str)) {
     _str = '_' + _str


### PR DESCRIPTION
# 问题起因
小程序进行了分包开发，主包里有个路径是 `pages/my-book/detail`，副包的目录是 `pages-my`，有一个页面是 `pages-my/book/detail`，这是两个完全不同的页面路径：

- 主包页面: `pages/my-book/detail`，在 `src/pages-json-js` 里的 js 变量是 `PagesMyBookDetail`
- 副包页面: `pages-my/book/detail`，在 `src/pages-json-js` 里的 js 变量是 `PagesMyBookDetail`

两个不同的路径，对应的 js 变量相同，导致 js 报错，无法启动应用。参考图如下：

<img width="965" height="254" alt="image" src="https://github.com/user-attachments/assets/4915eaf4-c49d-496f-8943-d1b3da53a597" />


# 改进方法
因此需要修改 js 变量生成逻辑。

- 不必要改成大驼峰格式（新增逻辑）
- 将路径分隔符换成`$`（新增逻辑）
- 将非字母、数字、换成`_`（改进逻辑）

因此修改后的路径对应的变量是：

- 主包页面: `pages/my-book/detail`，在 `src/pages-json-js` 里的 js 变量是 `pages$my_book$detail`
- 副包页面: `pages-my/book/detail`，在 `src/pages-json-js` 里的 js 变量是 `pages_my$book$detail`

此时，两个不同的路径，对应的 js 变量也不同，应用可以正常启动。参考图如下：

<img width="1020" height="254" alt="image" src="https://github.com/user-attachments/assets/ac23e47b-4e35-4b3d-b1af-f1c1f1e10588" />


# 前后对比
page.json 里直观体现是这样的：
```jsonc
{
  "pages": [
    {
      "path": "my-book/detail" // 原先 -> PagesMyBookDetail ❌重复了
    },
    {
      "path": "my-book/detail" // 现在 -> pages$my_book$detail ✅不重复
    }
  ],
  "subPackages": [
    {
      "root": "pages-my",
      "pages": [
        {
          "path": "book/detail" // 原先 -> PagesMyBookDetail ❌重复了
        },
        {
          "path": "book/detail" // 现在 -> pages_my$book$detail ✅不重复
        }
      ]
    }
  ]
}
```

# 引申思考
其实更安全的方法是使用 md5 等摘要算法，不过此改进方法已经在最大程度上避免了 js 变量的重复。