### PR TITLE
fix(mp-alipay): 修复 plugins export 字段不生效的 Bug

### DIFF
--- a/packages/uni-mp-vite/src/plugin/build.ts
+++ b/packages/uni-mp-vite/src/plugin/build.ts
@@ -176,7 +176,7 @@ function parseRollupInput(inputDir: string, platform: UniApp.PLATFORM) {
   if (process.env.UNI_MP_PLUGIN) {
     return inputOptions
   }
-  if (platform === 'mp-weixin') {
+  if (platform === 'mp-weixin' || platform === 'mp-alipay') {
     const pluginExports = getSubpackagePluginExports(inputDir)
     Object.keys(pluginExports).forEach((exportPath) => {
       inputOptions[exportPath] = pluginExports[exportPath]


### PR DESCRIPTION
[https://opendocs.alipay.com/mini/plugin/plugin-usage#%E5%AF%BC%E5%87%BA%E5%88%B0%E6%8F%92%E4%BB%B6](https://opendocs.alipay.com/mini/plugin/plugin-usage#%E5%AF%BC%E5%87%BA%E5%88%B0%E6%8F%92%E4%BB%B6)

<img width="2589" height="1269" alt="image" src="https://github.com/user-attachments/assets/807a75e0-c43b-4c2f-8eaa-7008bef8f724" />
