### PR TITLE
fix(mp-baidu): 修复 API navigateToMiniProgram 提示不支持 envVersion 的 Bug

### DIFF
--- a/packages/uni-mp-baidu/src/api/protocols.ts
+++ b/packages/uni-mp-baidu/src/api/protocols.ts
@@ -83,7 +83,6 @@ export const navigateToMiniProgram = {
   name: 'navigateToSmartProgram',
   args: {
     appId: 'appKey',
-    envVersion: false,
   },
 }
 


### PR DESCRIPTION
百度小程序官方文档 [https://smartprogram.baidu.com/docs/develop/api/open/swan-navigateToSmartProgram/](https://smartprogram.baidu.com/docs/develop/api/open/swan-navigateToSmartProgram/)

<img width="1630" height="1135" alt="image" src="https://github.com/user-attachments/assets/2656e3dc-8c05-491a-b016-f2c42006ade2" />

