### PR TITLE
fix(mp-alipay): 移除 connectSocket API 不支持 protocols 参数的警告

### DIFF
--- a/packages/uni-mp-alipay/src/api/protocols.ts
+++ b/packages/uni-mp-alipay/src/api/protocols.ts
@@ -296,7 +296,6 @@ export const chooseVideo = {
 export const connectSocket = {
   args: {
     method: false,
-    protocols: false,
   },
   // TODO 有没有返回值还需要测试下
 }


### PR DESCRIPTION
支付宝小程序已开始支持 `protocols`

<img width="2582" height="1248" alt="image" src="https://github.com/user-attachments/assets/9bb9a2f5-65f0-46cd-8daa-e3fdb9dcaa8d" />

[参考文档链接](https://opendocs.alipay.com/mini/api/vx19c3#Object%20object)