### PR TITLE
feat(mp): Magic Comments语法支持微信小程序跨分包自定义组件引用

### DIFF
--- a/packages/uni-cli-shared/lib/cache.js
+++ b/packages/uni-cli-shared/lib/cache.js
@@ -162,7 +162,7 @@ function parseComponentStyleIsolation (content) {
   }
 }
 
-function updateUsingComponents (name, usingComponents, type, content = '') {
+function updateUsingComponents (name, usingComponents, type, content = '', asyncCustomComponents) {
   if (type === 'Component') {
     componentSet.add(name)
   }
@@ -174,6 +174,12 @@ function updateUsingComponents (name, usingComponents, type, content = '') {
   const jsonObj = oldJsonStr ? JSON.parse(oldJsonStr) : {
     usingComponents
   }
+
+  // 异步分包自定义组件注册其他分包的组件引入
+  if (asyncCustomComponents && asyncCustomComponents.length) {
+    jsonObj.asyncCustomComponents = asyncCustomComponents
+  }
+
   if (type === 'Component') {
     jsonObj.component = true
     if (process.env.UNI_PLATFORM === 'mp-alipay') {

--- a/packages/webpack-uni-mp-loader/lib/plugin/generate-json.js
+++ b/packages/webpack-uni-mp-loader/lib/plugin/generate-json.js
@@ -1,7 +1,9 @@
 const path = require('path')
 
 const {
-  normalizePath
+  normalizePath,
+  hyphenate,
+  getComponentName
 } = require('@dcloudio/uni-cli-shared')
 
 const {
@@ -140,6 +142,18 @@ module.exports = function generateJson (compilation) {
       jsonObj.usingComponents = Object.assign(jsonObj.usingAutoImportComponents, jsonObj.usingComponents)
     }
     delete jsonObj.usingAutoImportComponents
+
+    // ----------------------(新增)
+    // 异步分包自定义组件注册其他分包的组件引入
+    if (jsonObj.asyncCustomComponents && jsonObj.asyncCustomComponents.length) {
+      const componentPlaceholder = jsonObj.asyncCustomComponents.reduce((p, n) => {
+        p[getComponentName(hyphenate(n.name))] = n.placeholder || 'view'
+        return p
+      }, {})
+      jsonObj.componentPlaceholder = Object.assign((jsonObj.componentPlaceholder || {}), componentPlaceholder)
+    }
+    delete jsonObj.asyncCustomComponents
+    // ----------------------
 
     // 百度小程序插件内组件使用 usingSwanComponents
     if (process.env.UNI_PLATFORM === 'mp-baidu') {


### PR DESCRIPTION
# **feat(mp): Magic Comments语法支持微信小程序异步分包组件**

**背景**

微信小程序官方支持"分包异步化"能力，允许跨分包异步引用自定义组件，这对于减小主包体积、优化启动性能具有重要意义。然而，uni-app Vue2 项目此前并不支持此功能，开发者无法享受到分包异步化带来的性能优势。

**解决方案**

本PR通过引入 **Magic Comments** 语法，为 uni-app Vue2 项目提供了完整的小程序异步分包组件支持。该方案具有以下特点：

- 🎯 **零侵入性**：使用标准 ES6 import 语法 + 注释，不影响现有代码
- 🔄 **跨平台兼容**：注释在非小程序平台自动忽略，完美兼容 H5/App 等
- 🛠️ **IDE 友好**：保持标准 import 语法，编辑器提供完整的智能提示和类型检查
- ⚙️ **配置灵活**：支持 JSON 格式配置，可指定平台和占位组件

**技术实现**

通过正则匹配特殊格式注释和紧随其后的 import 语句，在编译时：
1. 解析注释中的 JSON 配置获取 placeholder 和 platform 信息
2. 根据当前编译平台决定是否启用异步组件功能  
3. 自动生成小程序所需的 `componentPlaceholder` 配置
4. 处理完成后移除注释，保留标准 import 语句

**使用方法**

**基础用法：**
```javascript
/* @uni-async-component */
import EcCanvas from '@/subPackageB/components/ec-canvas'

export default {
  components: {
    EcCanvas
  }
}
```

**高级配置：**
```javascript
/* @uni-async-component {"placeholder": "view", "platform": "mp-weixin,mp-alipay"} */
import EcCanvas from '@/subPackageB/components/ec-canvas'
```

**配置参数说明：**
- `placeholder`: 占位组件类型，默认为 `"view"`
- `platform`: 目标平台，支持逗号分隔的多平台配置，默认为 `"mp-weixin"`

**编译结果**

在小程序平台编译时，上述代码会自动在页面 JSON 中生成：
```json
{
  "usingComponents": {
    "ec-canvas": "/subPackageB/components/ec-canvas"
  },
  "componentPlaceholder": {
    "ec-canvas": "view"
  }
}
```

**注意事项**

- ✅ **分包配置**：异步引用的组件必须位于 `pages.json` 中正确配置的分包内
- ✅ **占位组件**：占位组件在异步组件加载完成前提供临时 UI，避免页面结构异常
- ✅ **平台兼容**：在非目标平台（如 H5）中，注释会被忽略，组件按正常方式引入

**相关文件**

- `packages/webpack-uni-mp-loader/lib/script-new.js` - 核心处理逻辑
- `packages/webpack-uni-mp-loader/lib/plugin/generate-json.js` - JSON 生成逻辑

**测试**

该功能已在微信小程序平台测试验证，确保：
- 异步组件正确加载和渲染
- 占位组件正常显示
- 其他平台兼容性良好