### PR TITLE
fix(web): 修复 onPageNotFound 钩子获取不到页面 query 的 Bug (question/214796)

### DIFF
--- a/packages/uni-h5/src/framework/setup/index.ts
+++ b/packages/uni-h5/src/framework/setup/index.ts
@@ -248,7 +248,7 @@ export function setupApp(comp: any) {
               notFound: true,
               openType: 'appLaunch',
               path: route.path,
-              query: {},
+              query: decodedQuery(route.query),
               scene: 1001,
             }
             handleBeforeEntryPageRoutes()


### PR DESCRIPTION
[https://developers.weixin.qq.com/miniprogram/dev/api/base/app/app-event/wx.onPageNotFound.html](https://developers.weixin.qq.com/miniprogram/dev/api/base/app/app-event/wx.onPageNotFound.html)