### PR TITLE
fix: 修正快手开发者工具翻译的键名错误

### DIFF
--- a/packages/uni-cli-shared/src/messages/en.ts
+++ b/packages/uni-cli-shared/src/messages/en.ts
@@ -45,7 +45,7 @@ export default {
   'prompt.run.devtools.mp-harmony': 'HBuilderX',
   'prompt.run.devtools.mp-alipay': 'Alipay Mini Program Devtools',
   'prompt.run.devtools.mp-baidu': 'Baidu Mini Program Devtools',
-  'prompt.run.devtools.mp--kuaishou': 'Kuaishou Mini Program Devtools',
+  'prompt.run.devtools.mp-kuaishou': 'Kuaishou Mini Program Devtools',
   'prompt.run.devtools.mp-lark': 'Lark Mini Program Devtools',
   'prompt.run.devtools.mp-qq': 'QQ Mini Program Devtools',
   'prompt.run.devtools.mp-toutiao': 'Douyin Mini Program Devtools',

--- a/packages/uni-cli-shared/src/messages/zh_CN.ts
+++ b/packages/uni-cli-shared/src/messages/zh_CN.ts
@@ -45,7 +45,7 @@ export default {
   'prompt.run.devtools.mp-harmony': 'HBuilderX',
   'prompt.run.devtools.mp-alipay': '支付宝小程序开发者工具',
   'prompt.run.devtools.mp-baidu': '百度开发者工具',
-  'prompt.run.devtools.mp--kuaishou': '快手开发者工具',
+  'prompt.run.devtools.mp-kuaishou': '快手开发者工具',
   'prompt.run.devtools.mp-lark': '飞书开发者工具',
   'prompt.run.devtools.mp-qq': 'QQ小程序开发者工具',
   'prompt.run.devtools.mp-toutiao': '抖音开发者工具',


### PR DESCRIPTION
修复中英文翻译文件中快手开发者工具的键名错误，将多余的横线移除