### PR TITLE
fix: 修正快手开发者工具翻译的键名错误

### DIFF
--- a/packages/uni-cli-i18n/locales/en.json
+++ b/packages/uni-cli-i18n/locales/en.json
@@ -72,7 +72,7 @@
   "prompt.run.devtools.app-plus": "HBuilderX",
   "prompt.run.devtools.mp-alipay": "Alipay Mini Program Devtools",
   "prompt.run.devtools.mp-baidu": "Baidu Mini Program Devtools",
-  "prompt.run.devtools.mp--kuaishou": "Kuaishou Mini Program Devtools",
+  "prompt.run.devtools.mp-kuaishou": "Kuaishou Mini Program Devtools",
   "prompt.run.devtools.mp-lark": "Lark Mini Program Devtools",
   "prompt.run.devtools.mp-qq": "QQ Mini Program Devtools",
   "prompt.run.devtools.mp-toutiao": "Douyin Mini Program Devtools",

--- a/packages/uni-cli-i18n/locales/zh_CN.json
+++ b/packages/uni-cli-i18n/locales/zh_CN.json
@@ -72,7 +72,7 @@
   "prompt.run.devtools.app-plus": "HBuilderX",
   "prompt.run.devtools.mp-alipay": "支付宝小程序开发者工具",
   "prompt.run.devtools.mp-baidu": "百度开发者工具",
-  "prompt.run.devtools.mp--kuaishou": "快手开发者工具",
+  "prompt.run.devtools.mp-kuaishou": "快手开发者工具",
   "prompt.run.devtools.mp-lark": "飞书开发者工具",
   "prompt.run.devtools.mp-qq": "QQ小程序开发者工具",
   "prompt.run.devtools.mp-toutiao": "抖音开发者工具",


### PR DESCRIPTION
相似pr [https://github.com/dcloudio/uni-app/pull/5842](https://github.com/dcloudio/uni-app/pull/5842)