### PR TITLE
feat(input): support readonly

### DIFF
--- a/packages/uni-components/src/helpers/useField.ts
+++ b/packages/uni-components/src/helpers/useField.ts
@@ -100,6 +100,10 @@ export const props = /*#__PURE__*/ extend(
       type: [Boolean, String],
       default: false,
     },
+    readonly: {
+      type: Boolean,
+      default: false,
+    },
     /**
      * 已废弃属性，用于历史兼容
      */

--- a/packages/uni-components/src/vue/input/index.tsx
+++ b/packages/uni-components/src/vue/input/index.tsx
@@ -387,6 +387,7 @@ export default /*#__PURE__*/ defineBuiltInComponent({
               ['stop']
             )}
             disabled={!!props.disabled}
+            readonly={!!props.readonly}
             type={type.value}
             maxlength={state.maxlength}
             step={step.value}


### PR DESCRIPTION
支持 input 的 readonly 属性。disabled 的 input 元素无法响应任何事件包括 click，用 readonly 更好！
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/readonly
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/disabled