### PR TITLE
fix(mp-toutiao): 修复 video-player 组件编译属性丢失的 Bug (question/192086)

### DIFF
--- a/packages/uni-mp-toutiao/src/compiler/options.ts
+++ b/packages/uni-mp-toutiao/src/compiler/options.ts
@@ -34,6 +34,7 @@ export const customElements = [
   'shop-follow-card',
   'match-media',
   'mask',
+  'video-player',
   ...getNativeTags(process.env.UNI_INPUT_DIR, process.env.UNI_PLATFORM),
 ]
 


### PR DESCRIPTION
# 抖音链接 

目前抖音官方在QA处提供了uniapp项目的临时解决方案，方案不是很好，框架内部需要补充此组件为原生组件

[https://developer.open-douyin.com/docs/resource/zh-CN/mini-app/develop/industry-plugin/playlet-plugin/video-player](https://developer.open-douyin.com/docs/resource/zh-CN/mini-app/develop/industry-plugin/playlet-plugin/video-player)