### PR TITLE
fix(x-mp-alipay): 修复 createCanvasContextAsync API 在页面中使用 in 函数报错的 Bug

### DIFF
--- a/packages/uni-mp-core/src/api/x/createCanvasContextAsync.ts
+++ b/packages/uni-mp-core/src/api/x/createCanvasContextAsync.ts
@@ -67,10 +67,15 @@ export const createCanvasContextAsync = defineAsyncApi(
     if (!page || !page.$vm) {
       reject('current page invalid.')
     } else {
-      const query = options.component
-        ? __GLOBAL__.createSelectorQuery().in(options.component)
-        : __GLOBAL__.createSelectorQuery()
-      query
+      const query = __GLOBAL__.createSelectorQuery()
+      if (__PLATFORM__ === 'mp-alipay' && options.component) {
+        // 支付宝小程序 in 只支持在 Component 中使用，Page 中使用返回值为 null https://opendocs.alipay.com/mini/0cs688?pathHash=aba8a9f8#%E7%AE%80%E4%BB%8B
+        query.in = function () {
+          return this
+        }
+      }
+      const baseQuery = options.component ? query.in(options.component) : query
+      baseQuery
         .select('#' + options.id)
         .fields({ node: true, size: true }, () => {})
         .exec((res) => {


### PR DESCRIPTION
支付宝原生小程序测试项目如下

[example.zip](https://github.com/user-attachments/files/23649783/example.zip)

目前测试的结果是组件中可以正常获取canvas的相关参数，页面中不行，返回值为 null