### PR TITLE
fix(mp-weixin): 插件开发不支持 canIUse API  (question/215671)

### DIFF
--- a/packages/uni-mp-weixin/src/api/shims.ts
+++ b/packages/uni-mp-weixin/src/api/shims.ts
@@ -48,16 +48,16 @@ export function createSelectorQuery() {
 
 const wx = initWx()
 
-if (!__GLOBAL__.canIUse('getAppBaseInfo')) {
-  __GLOBAL__.getAppBaseInfo = __GLOBAL__.getSystemInfoSync
+if (!wx.getAppBaseInfo || !wx.getAppBaseInfo()) {
+  wx.getAppBaseInfo = wx.getSystemInfoSync
 }
 
-if (!__GLOBAL__.canIUse('getWindowInfo')) {
-  __GLOBAL__.getWindowInfo = __GLOBAL__.getSystemInfoSync
+if (!wx.getWindowInfo || !wx.getWindowInfo()) {
+  wx.getWindowInfo = wx.getSystemInfoSync
 }
 
-if (!__GLOBAL__.canIUse('getDeviceInfo')) {
-  __GLOBAL__.getDeviceInfo = __GLOBAL__.getSystemInfoSync
+if (!wx.getDeviceInfo || !wx.getDeviceInfo()) {
+  wx.getDeviceInfo = wx.getSystemInfoSync
 }
 
 let baseInfo = wx.getAppBaseInfo && wx.getAppBaseInfo()


### PR DESCRIPTION
# 微信

微信插件开发不支持 canIUse API，需要做兼容 

[https://developers.weixin.qq.com/miniprogram/dev/api/base/wx.canIUse.html](https://developers.weixin.qq.com/miniprogram/dev/api/base/wx.canIUse.html)