### PR TITLE
fix(h5): 修复 contentType 为 undefined 的情况

### DIFF
--- a/packages/uni-h5/src/service/api/network/request.ts
+++ b/packages/uni-h5/src/service/api/network/request.ts
@@ -251,6 +251,9 @@ function normalizeContentType(header: Record<string, string>) {
     delete header[name]
   }
   //#endif
+  if (!contentType) {
+    return 'string'
+  }
   if (contentType.indexOf('application/json') === 0) {
     return 'json'
   } else if (contentType.indexOf('application/x-www-form-urlencoded') === 0) {


### PR DESCRIPTION
<img width="1618" height="802" alt="屏幕截图 2025-12-25 204347" src="https://github.com/user-attachments/assets/86378642-8f42-4d4e-9963-052114a29721" />

例如使用 axios 时，开发者可能不指定 headers 中的 content-type，导致难以定位的 NPE 错误，建议开启 undefined 检查