### PR TITLE
fix(x-mp-weixin): 修复开启 virtualHost 时父亲组件动态更新 class 子组件不生效的问题

### DIFF
--- a/packages/uni-mp-core/src/runtime/componentOptions.ts
+++ b/packages/uni-mp-core/src/runtime/componentOptions.ts
@@ -4,6 +4,7 @@ import {
   type ComponentOptions,
   toRaw,
 } from 'vue'
+import { VIRTUAL_HOST_CLASS } from '@dcloudio/uni-shared'
 
 import {
   // @ts-expect-error
@@ -53,6 +54,28 @@ export function initPropsObserver(componentOptions: MPComponentOptions) {
       componentOptions.observers = {}
     }
     componentOptions.observers.uP = observe
+    if (
+      __X__ &&
+      componentOptions.options &&
+      componentOptions.options.virtualHost &&
+      componentOptions.properties &&
+      componentOptions.properties[VIRTUAL_HOST_CLASS]
+    ) {
+      const observeVirtualHostClass = function observeVirtualHostClass(
+        this: MPComponentInstance
+      ) {
+        if (!this.$vm) {
+          return
+        }
+        const instance = this.$vm.$
+        instance.effect.dirty = true
+        if (hasQueueJob(instance.update)) {
+          invalidateJob(instance.update)
+        }
+        instance.update()
+      }
+      componentOptions.observers[VIRTUAL_HOST_CLASS] = observeVirtualHostClass
+    }
   } else {
     ;(componentOptions.properties as any).uP.observer = observe
   }


### PR DESCRIPTION
close #5969 