### PR TITLE
fix(vite-plugin-uni): 修复 Windows 下 UTS 模块解析路径

### DIFF
--- a/packages/vite-plugin-uni/__tests__/resolve.spec.ts
+++ b/packages/vite-plugin-uni/__tests__/resolve.spec.ts
@@ -1,0 +1,66 @@
+import os from 'os'
+import path from 'path'
+import fs from 'fs-extra'
+import type { PluginContext } from 'rollup'
+
+import { customResolver } from '../src/config/resolve'
+
+describe('resolve', () => {
+  const originalEnv = {
+    UNI_PLATFORM: process.env.UNI_PLATFORM,
+    UNI_UTS_PLATFORM: process.env.UNI_UTS_PLATFORM,
+    UNI_INPUT_DIR: process.env.UNI_INPUT_DIR,
+    UNI_APP_X: process.env.UNI_APP_X,
+  }
+
+  let inputDir = ''
+
+  beforeEach(() => {
+    inputDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'vite-plugin-uni-resolve-')
+    )
+    process.env.UNI_PLATFORM = 'app'
+    process.env.UNI_UTS_PLATFORM = 'app-android'
+    process.env.UNI_INPUT_DIR = inputDir
+    process.env.UNI_APP_X = 'false'
+
+    fs.outputFileSync(
+      path.join(
+        inputDir,
+        'uni_modules/uts-button/utssdk/app-android/index.uts'
+      ),
+      'export const utsButton = 1'
+    )
+  })
+
+  afterEach(() => {
+    Object.entries(originalEnv).forEach(([key, value]) => {
+      if (value === undefined) {
+        Reflect.deleteProperty(process.env, key)
+      } else {
+        process.env[key] = value
+      }
+    })
+    if (inputDir) {
+      fs.removeSync(inputDir)
+    }
+  })
+
+  test('customResolver prefixes app uts absolute paths with /@fs/ on Windows', () => {
+    const utsModuleDir = path.join(inputDir, 'uni_modules/uts-button')
+    const pluginContext = {} as PluginContext
+    const resolved = customResolver.call(
+      pluginContext,
+      utsModuleDir,
+      undefined,
+      {
+        attributes: {},
+        isEntry: false,
+      }
+    )
+
+    expect(resolved).toBe(
+      '/@fs/' + utsModuleDir.replace(/\\/g, '/') + '?uts-proxy'
+    )
+  })
+})

--- a/packages/vite-plugin-uni/src/config/resolve.ts
+++ b/packages/vite-plugin-uni/src/config/resolve.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import type { Alias, ResolverFunction, UserConfig } from 'vite'
 import {
+  FS_PREFIX,
   extensions,
   isNormalCompileTarget,
   isWindows,
@@ -16,11 +17,14 @@ import type { VitePluginUniResolvedOptions } from '..'
 function resolveUTSModuleProxyFile(id: string, importer: string) {
   const file = resolveUTSAppModule(process.env.UNI_UTS_PLATFORM, id, importer)
   if (file) {
+    const normalizedFile = isWindows ? normalizePath(file) : file
     // app-js 会返回完整路径，不需要 uts-proxy
-    if (file.endsWith('.uts')) {
-      return file
+    if (normalizedFile.endsWith('.uts')) {
+      return isWindows ? FS_PREFIX + normalizedFile : normalizedFile
     }
-    return file + '?uts-proxy'
+    return isWindows
+      ? `${FS_PREFIX + normalizedFile}?uts-proxy`
+      : normalizedFile + '?uts-proxy'
   }
 }
 


### PR DESCRIPTION
## Summary

Fix Windows + Node.js v24 compatibility for app UTS module resolution in dev mode.

When app UTS modules are resolved to raw Windows absolute paths like `C:/...`, Vite may eventually pass them into ESM import flow, which can trigger:

ERR_UNSUPPORTED_ESM_URL_SCHEME
Only URLs with a scheme in: file, data, and node are supported...
Received protocol 'd:'
This patch makes the app UTS resolver return Vite-compatible /@fs/ module ids on Windows instead of bare absolute paths.

## Changes
update packages/vite-plugin-uni/src/config/resolve.ts
prefix Windows app UTS resolved paths with FS_PREFIX
preserve existing non-Windows behavior
add packages/vite-plugin-uni/__tests__/resolve.spec.ts
cover Windows app UTS resolver output for ?uts-proxy
## Why here
The failing path is in the dev resolver used by vite-plugin-uni, and this is the smallest upstream-compatible fix:

it keeps existing UTS resolution logic
it follows Vite’s existing /@fs/ convention for filesystem paths
it avoids relying on Node loader hooks or user-side workarounds
## Verification
Passed:

pnpm exec jest --runInBand --runTestsByPath "packages/vite-plugin-uni/__tests__/resolve.spec.ts"
pnpm exec jest --runInBand packages/vite-plugin-uni/__tests__/static.spec.ts packages/vite-plugin-uni/__tests__/sourcemap.spec.ts
## Context
This addresses a Windows + Node.js v24 issue where bare absolute filesystem paths are no longer accepted when they later reach ESM import handling.