### PR TITLE
fix(x-mp-alipay): 移除 picker-view 默认重置样式避免 picker-view-column 排列异常

### DIFF
--- a/packages/uni-mp-vite/lib/uvue.css
+++ b/packages/uni-mp-vite/lib/uvue.css
@@ -40,7 +40,9 @@ navigation-bar,
 navigator,
 open-data,
 page-meta,
+/* #ifndef MP-ALIPAY */ 
 picker-view,
+/* #endif */
 picker,
 progress,
 radio-group,


### PR DESCRIPTION
修改前

<img width="528" height="862" alt="image" src="https://github.com/user-attachments/assets/2cb39b36-206e-414f-bfc2-4cb049ccc283" />

修改后

<img width="465" height="827" alt="image" src="https://github.com/user-attachments/assets/a1873bc5-3e54-496f-9385-265d451403aa" />
