### PR TITLE
fix(web): 修复页面切换时 App 样式作用域失效 #31925

### DIFF
--- a/packages/uni-h5/src/framework/setup/page.ts
+++ b/packages/uni-h5/src/framework/setup/page.ts
@@ -294,13 +294,7 @@ export function onPageShow(
   instance: ComponentInternalInstance,
   pageMeta: UniApp.PageRouteMeta
 ) {
-  if (__X__) {
-    const type = instance.type as { styleIsolation?: string }
-    if (type.styleIsolation !== 'isolated') {
-      const scopeId = getScopeId(instance.root)
-      scopeId && updateCurPageBodyScopeId(scopeId)
-    }
-  }
+  updateCurPageBodyScopeId(instance)
   updateBodyScopeId(instance)
   updateCurPageCssVar(pageMeta)
   updateCurPageAttrs(pageMeta)
@@ -311,17 +305,28 @@ export function onPageShow(
 }
 
 export function onPageReady(instance: ComponentInternalInstance) {
-  const scopeId = getScopeId(instance)
-  scopeId && updateCurPageBodyScopeId(scopeId)
-}
-
-function updateCurPageBodyScopeId(scopeId: string) {
-  const pageBodyEl = document.querySelector('uni-page-body')
-  if (pageBodyEl) {
-    pageBodyEl.setAttribute(scopeId, '')
-  } else if (__DEV__) {
+  if (!updateCurPageBodyScopeId(instance) && __DEV__) {
     console.warn('uni-page-body not found')
   }
+}
+
+function updateCurPageBodyScopeId(instance: ComponentInternalInstance) {
+  const pageRoot = getPageInstanceByChild(instance)?.subTree
+    ?.el as Element | null
+  const pageBodyEl = pageRoot?.querySelector?.('uni-page-body')
+  if (!pageBodyEl) {
+    return false
+  }
+
+  const type = instance.type as { styleIsolation?: string }
+  if (__X__ && type.styleIsolation !== 'isolated') {
+    const appScopeId = getScopeId(instance.root)
+    appScopeId && pageBodyEl.setAttribute(appScopeId, '')
+  }
+
+  const pageScopeId = getScopeId(instance)
+  pageScopeId && pageBodyEl.setAttribute(pageScopeId, '')
+  return true
 }
 
 function getScopeId(instance: ComponentInternalInstance) {


### PR DESCRIPTION
## 问题原因

`App.uvue` 引入的 CSS 经过 scoped 编译后，`page` 选择器会转换为带 App scopeId 的 `uni-page-body` 选择器。

运行时需要将对应的 scopeId 写入当前页面的 `uni-page-body`，相关样式及 CSS 变量才能生效。

原逻辑通过以下代码全局查找节点：

```ts
document.querySelector('uni-page-body')
```

页面跳转期间，新旧页面的 uni-page-body 可能同时存在。全局查询可能命中离场页面，导致 scopeId 写入错误节点，当前页面无法匹配 App 中定义的 scoped 样式。
因此，该问题本质上不是 CSS 文件加载失败，而是当前页面的 uni-page-body 缺少正确的 scopeId。后续页面显示时如果仍然命中错误节点，CSS 变量也不会自行恢复。

## 修复方案
- 根据当前页面实例定位其对应的 uni-page-body，避免依赖全局 DOM 顺序。
- 普通 Web/H5 页面写入页面 scopeId。
- X Web 非 isolated 页面额外写入 App scopeId。
- 保留 onPageShow 调用，覆盖页面首次显示及 KeepAlive 激活场景。
- 在 onPageReady 中再次执行，补偿首次挂载时 DOM 尚未生成的情况。
- 对页面节点及 DOM API 调用增加容错，避免节点不存在时产生运行时异常。

## 修复结论
- 修复后，scopeId 会写入当前页面对应的 uni-page-body，不会再因页面切换期间命中离场页面而导致 App 全局 CSS 变量失效。
- 该修改同时覆盖普通 Web/H5 和 X Web，并保持原有样式隔离规则不变：
- 普通页面继续应用页面 scopeId。
- X Web 非 isolated 页面应用 App scopeId。
- isolated 页面不会错误继承 App 样式。
- KeepAlive 页面重新显示时会重新确认并写入 scopeId。