### PR TITLE
fix(mp): 支持 Vue 3.4 v-bind same-name shorthand

### DIFF
--- a/packages/uni-mp-compiler/__tests__/vBind.spec.ts
+++ b/packages/uni-mp-compiler/__tests__/vBind.spec.ts
@@ -106,7 +106,7 @@ describe('compiler: transform v-bind', () => {
         },
       },
     })
-    parseWithVBind(`<view v-bind:arg />`, { onError })
+    parseWithVBind(`<view v-bind:arg="" />`, { onError })
     expect(onError.mock.calls[1][0]).toMatchObject({
       code: ErrorCodes.X_V_BIND_NO_EXPRESSION,
       loc: {
@@ -116,10 +116,34 @@ describe('compiler: transform v-bind', () => {
         },
         end: {
           line: 1,
-          column: 17,
+          column: 20,
         },
       },
     })
+  })
+
+  test('same-name shorthand (Vue 3.4)', () => {
+    assert(
+      `<view :id/>`,
+      `<view id="{{a}}"/>`,
+      `(_ctx, _cache) => {
+  return { a: _ctx.id }
+}`
+    )
+    assert(
+      `<view v-bind:arg />`,
+      `<view arg="{{a}}"/>`,
+      `(_ctx, _cache) => {
+  return { a: _ctx.arg }
+}`
+    )
+    assert(
+      `<view :foo-bar/>`,
+      `<view foo-bar="{{a}}"/>`,
+      `(_ctx, _cache) => {
+  return { a: _ctx.fooBar }
+}`
+    )
   })
 
   test('.camel modifier', () => {

--- a/packages/uni-mp-compiler/src/transforms/vBind.ts
+++ b/packages/uni-mp-compiler/src/transforms/vBind.ts
@@ -8,10 +8,39 @@ import {
 } from '@vue/compiler-core'
 import type { DirectiveTransform } from '../transform'
 import { MPErrorCodes, createMPCompilerError } from '../errors'
+import { processExpression } from './transformExpression'
 
 export const transformBind: DirectiveTransform = (dir, _node, context) => {
-  const { exp, modifiers, loc } = dir
+  const { modifiers, loc } = dir
   const arg = dir.arg!
+  let { exp } = dir
+
+  // 空字符串表达式仍是错误（Vue: `:id=""`）
+  if (exp && exp.type === NodeTypes.SIMPLE_EXPRESSION && !exp.content.trim()) {
+    context.onError(createCompilerError(ErrorCodes.X_V_BIND_NO_EXPRESSION, loc))
+    return {
+      props: [createObjectProperty(arg, createSimpleExpression('', true, loc))],
+    }
+  }
+
+  // Vue 3.4 同名简写：`:id` => `:id="id"`
+  if (!exp) {
+    if (arg.type !== NodeTypes.SIMPLE_EXPRESSION || !arg.isStatic) {
+      context.onError(
+        createCompilerError(ErrorCodes.X_V_BIND_INVALID_SAME_NAME_ARGUMENT, loc)
+      )
+      return {
+        props: [
+          createObjectProperty(arg, createSimpleExpression('', true, loc)),
+        ],
+      }
+    }
+    const propName = camelize(arg.content)
+    exp = dir.exp = createSimpleExpression(propName, false, arg.loc)
+    if (context.prefixIdentifiers) {
+      exp = dir.exp = processExpression(exp, context)
+    }
+  }
 
   if (arg.type !== NodeTypes.SIMPLE_EXPRESSION) {
     arg.children.unshift(`(`)
@@ -43,16 +72,6 @@ export const transformBind: DirectiveTransform = (dir, _node, context) => {
     context[context.isX ? 'onError' : 'onWarn'](
       createMPCompilerError(MPErrorCodes.X_V_BIND_MODIFIER_ATTR, loc)
     )
-  }
-
-  if (
-    !exp ||
-    (exp.type === NodeTypes.SIMPLE_EXPRESSION && !exp.content.trim())
-  ) {
-    context.onError(createCompilerError(ErrorCodes.X_V_BIND_NO_EXPRESSION, loc))
-    return {
-      props: [createObjectProperty(arg, createSimpleExpression('', true, loc))],
-    }
   }
 
   return {


### PR DESCRIPTION
## Summary
- Vue 3.4 起 `:id` 等价于 `:id="id"`。`uni-mp-compiler` 的 `transformBind` 把缺失 `exp` 一律当成 `X_V_BIND_NO_EXPRESSION`，产物变成 `id="{{}}"`。
- 对照 `@vue/compiler-core@3.4.21` 的 `transformBind`：空字符串表达式仍报 34；无表达式且 arg 静态时填 `camelize(arg.content)`，并走 `processExpression`。
- 空 `v-bind:arg=""` 继续报错；`<view v-bind />`（无 arg）仍是 `X_V_BIND_NO_ARGUMENT`。

## Test plan
- [x] `jest packages/uni-mp-compiler/__tests__/vBind.spec.ts` — 13 passed（含 `same-name shorthand (Vue 3.4)`：`:id` / `v-bind:arg` / `:foo-bar`）
- [x] 用 CLI 建一个 mp-weixin 页面，模板写 `<view :id>`，确认 wxml 为 `id="{{a}}"` 且 render 含 `_ctx.id`