### PR TITLE
fix(mp-toutiao): 停止对同步子组件强制注入 componentPlaceholder

### DIFF
--- a/packages/uni-cli-shared/__tests__/cache.spec.js
+++ b/packages/uni-cli-shared/__tests__/cache.spec.js
@@ -80,31 +80,31 @@ describe('shared:cache', () => {
   })
 
   it('mp-toutiao generate component.json', () => {
+    const prevPlatform = process.env.UNI_PLATFORM
     process.env.UNI_PLATFORM = 'mp-toutiao'
-    const name = 'components/component-tag-name'
+    // 独立 name：覆盖 add 与 update。不得再强制注入 componentPlaceholder（#6057）
+    const name = 'components/toutiao-no-force-placeholder'
     let usingComponents = {
       'my-component': '/components/component-tag-name'
-    }
-    const componentPlaceholder = {
-      'my-component': 'view'
     }
     updateUsingComponents(name, usingComponents, 'Component')
     let componentJsonStr = getChangedJsonFileMap().get(name + '.json')
     expect(componentJsonStr).toBe(JSON.stringify({
       usingComponents,
-      component: true,
-      componentPlaceholder
+      component: true
     }, null, 2))
     expect(0).toBe(getChangedJsonFileMap().size)
 
-    usingComponents = {}
+    usingComponents = {
+      'u-icon': '/components/u-icon'
+    }
     updateUsingComponents(name, usingComponents, 'Component')
     componentJsonStr = getChangedJsonFileMap().get(name + '.json')
     expect(componentJsonStr).toBe(JSON.stringify({
       usingComponents,
-      component: true,
-      componentPlaceholder
+      component: true
     }, null, 2))
     expect(0).toBe(getChangedJsonFileMap().size)
+    process.env.UNI_PLATFORM = prevPlatform
   })
 })

--- a/packages/uni-cli-shared/lib/cache.js
+++ b/packages/uni-cli-shared/lib/cache.js
@@ -200,18 +200,6 @@ function updateUsingComponents (name, usingComponents, type, content = '') {
   }
   if (oldJsonStr) { // update
     jsonObj.usingComponents = usingComponents
-    // 嵌套组件获取 props 为 null，使用占组件修正父子组件生命周期执行顺序 https://developer.open-douyin.com/docs/resource/zh-CN/mini-app/develop/tutorial/custom-component/placeholder
-    if (process.env.UNI_PLATFORM === 'mp-toutiao') {
-      if (type === 'Component') {
-        const usingComponentnames = Object.keys(jsonObj.usingComponents)
-        if (usingComponentnames.length) {
-          jsonObj.componentPlaceholder = {}
-          usingComponentnames.forEach(componentName => {
-            jsonObj.componentPlaceholder[componentName] = 'view'
-          })
-        }
-      }
-    }
     const newJsonStr = JSON.stringify(jsonObj, null, 2)
     if (newJsonStr !== oldJsonStr) {
       updateJsonFile(name, newJsonStr)


### PR DESCRIPTION
## Summary
- 修复 #6057：`uni-cli-shared` 的 `updateUsingComponents` 在 `mp-toutiao` 的 Component **update** 路径上，把全部 `usingComponents` 写成 `componentPlaceholder: "view"`。
- 对照[抖音占位组件文档](https://developer.open-douyin.com/docs/resource/zh-CN/mini-app/develop/tutorial/custom-component/placeholder)：`componentPlaceholder` 只用于延迟注入。同步子组件（uView / 本地组件）被写成 `view` 后，新基础库会按占位规则降级成空 `<view>`。
- 方案 A：删除该强制注入。需要占位的组件仍可在自身 json 里手写 `componentPlaceholder`。Vue3 `next` 本来就没有这段逻辑。

## Test plan
- [x] `packages/uni-cli-shared/__tests__/cache.spec.js` — `mp-toutiao generate component.json` 覆盖 add + update，产物不再含自动 `componentPlaceholder`
- [x] 对照矩阵：toutiao Component update 同步子组件不再注入；weixin / Page / App 行为不变
- [ ] 用 issue 附件 demo 在抖音开发者工具编译 mp-toutiao，确认自定义组件不再被降成空 `<view>`