### PR TITLE
fix(mp-vite): 仅被独立分包引用的 npm 打进分包 vendor

### DIFF
--- a/packages/uni-mp-vite/__tests__/independentVendorChunk.spec.ts
+++ b/packages/uni-mp-vite/__tests__/independentVendorChunk.spec.ts
@@ -1,0 +1,76 @@
+import { IndependentVendorChunk } from '../src/plugin/independentVendorChunk'
+import { virtualPagePath } from '../src/plugins/entry'
+
+const inputDir = '/proj/src'
+const independentRoots = ['pkg6051indep/']
+
+describe('IndependentVendorChunk.resolve', () => {
+  test('only independent subpackage importers go to that vendor', () => {
+    expect(
+      IndependentVendorChunk.resolve(
+        [`${inputDir}/pkg6051indep/class-probe.vue?vue&type=script`],
+        inputDir,
+        independentRoots
+      )
+    ).toBe('pkg6051indep/common/vendor')
+  })
+
+  test('regular subpackage importers stay on main vendor', () => {
+    expect(
+      IndependentVendorChunk.resolve(
+        [`${inputDir}/pkg6051/class-probe.vue`],
+        inputDir,
+        independentRoots
+      )
+    ).toBeUndefined()
+  })
+
+  test('shared with main package stays on main vendor', () => {
+    expect(
+      IndependentVendorChunk.resolve(
+        [
+          `${inputDir}/pkg6051indep/class-probe.vue`,
+          `${inputDir}/pages/index/index.vue`,
+        ],
+        inputDir,
+        independentRoots
+      )
+    ).toBeUndefined()
+  })
+
+  test('shared by two independent subpackages stays on main vendor', () => {
+    expect(
+      IndependentVendorChunk.resolve(
+        [
+          `${inputDir}/pkg6051indep/a.vue`,
+          `${inputDir}/pkgOther/b.vue`,
+        ],
+        inputDir,
+        ['pkg6051indep/', 'pkgOther/']
+      )
+    ).toBeUndefined()
+  })
+
+  test('virtual page importer resolves into the independent root', () => {
+    expect(
+      IndependentVendorChunk.resolve(
+        [virtualPagePath('pkg6051indep/class-probe.vue')],
+        inputDir,
+        independentRoots
+      )
+    ).toBe('pkg6051indep/common/vendor')
+  })
+
+  test('empty importers or roots do not move the chunk', () => {
+    expect(
+      IndependentVendorChunk.resolve(
+        [`${inputDir}/pkg6051indep/class-probe.vue`],
+        inputDir,
+        []
+      )
+    ).toBeUndefined()
+    expect(
+      IndependentVendorChunk.resolve([], inputDir, independentRoots)
+    ).toBeUndefined()
+  })
+})

--- a/packages/uni-mp-vite/src/plugin/build.ts
+++ b/packages/uni-mp-vite/src/plugin/build.ts
@@ -31,6 +31,7 @@ import {
   parseVirtualComponentPath,
   parseVirtualPagePath,
 } from '../plugins/entry'
+import { IndependentVendorChunk } from './independentVendorChunk'
 
 const debugChunk = debug('uni:chunk')
 
@@ -240,7 +241,8 @@ function createMoveToVendorChunkFn(): GetManualChunk | undefined {
         }
         return
       }
-      const { hasOptimizationSubPackages, subPackages } = getSubPackages()
+      const { hasOptimizationSubPackages, subPackages, independentSubPackages } =
+        getSubPackages()
       // 处理子包引用的 node_modules 中的文件
       if (
         hasOptimizationSubPackages &&
@@ -263,6 +265,17 @@ function createMoveToVendorChunkFn(): GetManualChunk | undefined {
         if (matchSubPackages.size === 1) {
           return `${matchSubPackages.values().next().value}common/vendor`
         }
+      }
+      // 独立分包不能引用主包 JS。仅被某一个独立分包引用的 npm 打进该分包 vendor。
+      // 不依赖 optimization.subPackages：这是微信运行时正确性，不是体积优化。
+      const independentVendor = IndependentVendorChunk.resolve(
+        getModuleInfo(id)?.importers || [],
+        inputDir,
+        independentSubPackages
+      )
+      if (independentVendor) {
+        debugChunk(independentVendor, normalizedId)
+        return independentVendor
       }
       // 非项目内的 js 资源，均打包到 vendor
       debugChunk('common/vendor', normalizedId)

--- a/packages/uni-mp-vite/src/plugin/independentVendorChunk.ts
+++ b/packages/uni-mp-vite/src/plugin/independentVendorChunk.ts
@@ -1,0 +1,61 @@
+/**
+ * 独立分包 npm vendor 落点。
+ * 微信独立分包不能 require 主包 JS；仅当全部 importer 落在同一个独立分包根下时，
+ * 才把该 npm 打进 `{root}common/vendor`，否则保持主包 common/vendor。
+ */
+import path from 'path'
+import { normalizePath } from '@dcloudio/uni-cli-shared'
+import {
+  isUniComponentUrl,
+  isUniPageUrl,
+  parseVirtualComponentPath,
+  parseVirtualPagePath,
+} from '../plugins/entry'
+
+export namespace IndependentVendorChunk {
+  export function resolveImporterFile(
+    importer: string,
+    inputDir: string
+  ): string {
+    const raw = normalizePath(importer)
+    if (isUniPageUrl(raw)) {
+      return normalizePath(path.resolve(inputDir, parseVirtualPagePath(raw)))
+    }
+    if (isUniComponentUrl(raw)) {
+      return normalizePath(
+        path.resolve(inputDir, parseVirtualComponentPath(raw))
+      )
+    }
+    return raw.split('?')[0]
+  }
+
+  /**
+   * 微信独立分包不能引用主包 JS。
+   * 仅当全部 importer 落在同一个独立分包根下时，把 npm 打进 `{root}common/vendor`。
+   */
+  export function resolve(
+    importers: readonly string[],
+    inputDir: string,
+    independentRoots: readonly string[]
+  ): string | undefined {
+    if (!importers.length || !independentRoots.length) {
+      return
+    }
+    const normalizedInput = normalizePath(inputDir)
+    const matched = new Set<string>()
+    for (const importer of importers) {
+      const file = resolveImporterFile(importer, normalizedInput)
+      const root = independentRoots.find((subPackagePath) =>
+        file.startsWith(`${normalizedInput}/${subPackagePath}`)
+      )
+      if (!root) {
+        return
+      }
+      matched.add(root)
+    }
+    if (matched.size !== 1) {
+      return
+    }
+    return `${[...matched][0]}common/vendor`
+  }
+}

--- a/packages/uni-mp-vite/src/plugins/entry.ts
+++ b/packages/uni-mp-vite/src/plugins/entry.ts
@@ -59,12 +59,17 @@ export function parseComponentStyleIsolation(content: string) {
 
 let hasOptimizationSubPackages = false // 是否开启分包优化配置
 let subPackages: string[] = []
+let independentSubPackages: string[] = []
+function normalizeSubPackageRoot(root: string) {
+  return `${root.replace(/\/$/, '')}/`
+}
 function initSubPackages() {
   const inputDir = normalizePath(process.env.UNI_INPUT_DIR)
   const pagesJsonFile = path.resolve(inputDir, 'pages.json')
   if (!fs.existsSync(pagesJsonFile)) {
     hasOptimizationSubPackages = false
     subPackages = []
+    independentSubPackages = []
     return
   }
   const platform = process.env.UNI_PLATFORM
@@ -76,14 +81,19 @@ function initSubPackages() {
     platform,
     { subpackages: true }
   )
-  subPackages = Object.values(appJson.subPackages || appJson.subpackages || {})
-    .filter(Boolean)
-    .map(({ root }) => `${root.replace(/\/$/, '')}/`)
+  const packages = Object.values(
+    appJson.subPackages || appJson.subpackages || {}
+  ).filter(Boolean)
+  subPackages = packages.map(({ root }) => normalizeSubPackageRoot(root))
+  independentSubPackages = packages
+    .filter((pkg) => pkg.independent)
+    .map(({ root }) => normalizeSubPackageRoot(root))
 }
 export function getSubPackages() {
   return {
     hasOptimizationSubPackages,
     subPackages,
+    independentSubPackages,
   }
 }
 


### PR DESCRIPTION
## Summary
- 修复 #6051：独立分包页 `import { LibClass } from 'lib'` 时，`uni-mp-vite` 仍把根目录 `node_modules` 打进主包 `common/vendor.js`。独立分包冷启动 `require('../common/vendor.js')` 会被微信拒绝（`module 'common/vendor.js' is not defined`），看起来像 `e` 为 `undefined` / `LibClass is not a constructor`。
- 微信规定独立分包不能引用主包 JS。仅当某个 npm **只被一个独立分包**引用时，改打到 `{root}common/vendor.js`。主包或普通分包也引用时，仍走主包 vendor（普通分包可以引用主包，这条本来就是好的）。
- 不依赖 `optimization.subPackages`：现有分包优化只处理嵌套的 `uni_modules/.../node_modules`，且那是体积优化；独立分包是运行时正确性。

## Test plan
- [x] `packages/uni-mp-vite/__tests__/independentVendorChunk.spec.ts`：只被独立分包引用 → `{root}common/vendor`；普通分包 / 与主包共享 / 两个独立分包共享 → 不搬。
- [ ] 独立分包冷启动（编译模式直接进分包页，不要先开首页）：产物应有 `{root}common/vendor.js`，页面 `require` 指向分包 vendor，`new LibClass()` 成功。
- [ ] 普通分包、以及主包+独立分包同时引用同一个 npm：模块仍在主包 `common/vendor.js`。