### PR TITLE
fix(uni-app-vite): renderjs 块编译未继承 vite 的 resolve.alias

### DIFF
--- a/packages/uni-app-vite/src/vue/plugins/renderjs.ts
+++ b/packages/uni-app-vite/src/vue/plugins/renderjs.ts
@@ -20,6 +20,8 @@ export const APP_RENDERJS_JS = 'app-renderjs.js'
 
 const wxsModulesCache = new WeakMap<ResolvedConfig, Map<string, string>>()
 const renderjsModulesCache = new WeakMap<ResolvedConfig, Map<string, string>>()
+// resolvedConfig 在 configResolved 之后不再变化，alias 映射可安全缓存
+const esbuildAliasCache = new WeakMap<ResolvedConfig, Record<string, string>>()
 export function uniRenderjsPlugin(): Plugin {
   let resolvedConfig: ResolvedConfig
   let userConfig: UserConfig
@@ -67,7 +69,8 @@ export function uniRenderjsPlugin(): Plugin {
               filename,
               `__${globalName}['${moduleHashId}']`,
               isProduction,
-              userConfig
+              userConfig,
+              resolvedConfig
             ),
         globalName,
         isProduction
@@ -155,7 +158,8 @@ function transformRenderjs(
   filename: string,
   globalName: string,
   isProduction: boolean,
-  config: UserConfig
+  config: UserConfig,
+  resolvedConfig: ResolvedConfig
 ) {
   return transformWithEsbuild(code, filename, {
     format: 'iife',
@@ -164,10 +168,29 @@ function transformRenderjs(
     minify: isProduction ? true : false,
     bundle: true,
     write: false,
+    alias: resolveEsbuildAlias(resolvedConfig),
   }).then((res) => {
     if (res.outputFiles) {
       return res.outputFiles[0].text
     }
     return ''
   })
+}
+
+// renderjs 块由独立 esbuild 打包（bundle: true），拿不到 vite 的 resolve.alias，
+// 依赖库中的 import('node:module') 之类会解析失败，这里用 resolvedConfig 的 alias 补齐。
+// esbuild 的 alias 仅支持精确匹配/<key>/ 前缀替换，故只透传 string 型 find。
+function resolveEsbuildAlias(resolvedConfig: ResolvedConfig) {
+  let alias = esbuildAliasCache.get(resolvedConfig)
+  if (!alias) {
+    const next: Record<string, string> = {}
+    for (const { find, replacement } of resolvedConfig.resolve.alias) {
+      if (typeof find === 'string') {
+        next[find] = replacement
+      }
+    }
+    alias = next
+    esbuildAliasCache.set(resolvedConfig, next)
+  }
+  return alias
 }


### PR DESCRIPTION
### 问题

renderjs 块的编译走独立的 esbuild 调用（`bundle: true`），**没有继承 vite 的 `resolve.alias`**。
因此当 renderjs 块引用的第三方依赖内部含 `import('node:module')`（典型场景：wasm 包的 Emscripten glue），
而项目通过 `resolve.alias` 把它指向浏览器 shim 时，编译直接失败：

```
[plugin:uni:app-vue-renderjs] X [ERROR] Could not resolve "node:module"
    node_modules/<pkg>/generated/*.mjs:1:312
```

### 改动

- `transformRenderjs` 增加 `resolvedConfig` 形参，调用处传入；
- 从 `resolvedConfig.resolve.alias` 提取 string 型 `find` 组成 esbuild `alias` 并透传，按 `resolvedConfig` 用 WeakMap 缓存（`configResolved` 之后不再变化）；
- 注释说明 esbuild 的 alias 只支持精确匹配 / `<key>/` 前缀替换，故仅透传 string 型 `find`。

### 验证

- 真实项目（`@dcloudio/*@3.0.0-5000720260410001`）：改动前 App 平台构建报 `Could not resolve "node:module"`，改动后 `build:app` 通过，产物 `app-renderjs.js` 中 `node:module` 零残留；
- `DEBUG=uni:app-renderjs` 可看到实际透传给 esbuild 的 alias 为 `vue-i18n,plugin-vue:export-helper,node:module`；
- 注意：H5 / mp-weixin 构建会整块剥离 renderjs（`APP-PLUS` 条件编译），不能用于验证该改动。

### 影响面

仅影响 renderjs 块的 esbuild 编译；alias 语义与 vite 侧对齐（RegExp 型 `find` 保持不生效）。
`transformWxs` 结构相同、有同样隐患，本次未包含。